### PR TITLE
Feature/graph commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 > Due to a versioning mistake, the official stable API will be defined in v2.0.0.
 **All `v1.x.x` versions should be considered unstable.**
 
+## v1.9.0
+### Added
+- new `Database#commit` method applies many updates simultaneously.
+
+### Changed
+- Hooks can no longer intercept the `context` property on writes. All updates are expressed as a graph.
+
 ## v1.8.1
 ### Fixed
 - Bug preventing node field updates.

--- a/src/database/root.js
+++ b/src/database/root.js
@@ -83,8 +83,7 @@ class Database extends Graph {
     const deltas = this.merge(contexts);
 
     return await pipeline.after.write(this[settings], {
-      update: config.update,
-      graph: config.graph,
+      ...config,
       ...deltas,
     });
   }
@@ -97,57 +96,28 @@ class Database extends Graph {
    * @return {Context} - Resolves to the context written.
    */
   async write (uid, value, options = {}) {
-    const config = this[settings];
-    const update = new Context(this, { uid });
-    const currentState = this.value(uid);
 
-    // HACK: Fixes critical issue where node states aren't incremented.
-    // Safe to refactor once Database#commit() is implemented.
-    if (value && currentState) {
-      const existing = currentState.new();
+    // Turn the object into a database context.
+    const context = new Context(this, { uid });
+    const current = this.value(uid);
 
-      for (const key in value) {
-        if (value.hasOwnProperty(key)) {
-          if (currentState.state(key)) {
-            existing.merge({ [key]: currentState.value(key) });
-            existing.meta(key).state = currentState.state(key);
-          }
+    // Ensure object updates increment state.
+    if (current && value) {
+      for (const field in value) {
+        if (value.hasOwnProperty(field)) {
+          context.merge({ [field]: current.value(field) });
+          context.meta(field).state = current.state(field);
         }
       }
-
-      update.merge(existing);
     }
 
-    update.merge(value);
+    context.merge(value);
 
-    let fullState = update;
+    const update = Graph.source({ [uid]: context });
 
-    if (currentState) {
-      fullState = update.new();
+    await this.commit(update, options);
 
-      fullState.merge(currentState);
-      fullState.merge(update);
-    }
-
-    const params = await pipeline.before.write(config, {
-      ...options,
-      graph: Graph.source({ [uid]: fullState }),
-    });
-
-    this.merge({ [uid]: update });
-    const node = this.value(uid);
-
-    /** Persist the change. */
-    for (const store of params.storage) {
-      await store.write(params);
-    }
-
-    const { context } = await pipeline.after.write(config, {
-      ...options,
-      context: node,
-    });
-
-    return context;
+    return this.value(uid);
   }
 
   /**

--- a/src/database/test/hooks.test.js
+++ b/src/database/test/hooks.test.js
@@ -75,14 +75,6 @@ describe('Database hook', () => {
       expect(hook).toHaveBeenCalled();
     });
 
-    it('should be passed the context', async () => {
-      const settings = await db.write('settings', {
-        enabled: true,
-      });
-      const [{ context }] = hook.calls[0].arguments;
-      expect(context).toBe(settings);
-    });
-
     it('should be passed the options', async () => {
       await db.write('beans', {}, {
         cool: true,
@@ -91,14 +83,6 @@ describe('Database hook', () => {
       const [write] = hook.calls[0].arguments;
       expect(write).toContain({
         cool: true,
-      });
-    });
-
-    it('should allow overriding of the return context', async () => {
-      hook.andCall((write) => ({ ...write, context: { trickery: true } }));
-      const result = await db.write('beans', {});
-      expect(result).toEqual({
-        trickery: true,
       });
     });
 

--- a/src/database/test/root.test.js
+++ b/src/database/test/root.test.js
@@ -154,6 +154,14 @@ describe('Database', () => {
       expect(result.history).toBeA(Graph);
       expect(result.update).toBeA(Graph);
     });
+
+    it('transforms nodes into DB contexts', async () => {
+      node.merge({ count: 1 });
+      await db.commit(graph);
+
+      const { uid } = node.meta();
+      expect(db.value(uid)).toBeA(Context);
+    });
   });
 
   describe('write', () => {

--- a/src/database/test/root.test.js
+++ b/src/database/test/root.test.js
@@ -186,6 +186,16 @@ describe('Database', () => {
       expect(await user.read('handle')).toBe('BobTheGreat');
     });
 
+    it('updates node fields', async () => {
+      const user = await db.write('user', { followers: 50 });
+
+      await db.write('user', { followers: 49 });
+      expect(await user.read('followers')).toBe(49);
+
+      await db.write('user', { followers: 51 });
+      expect(await user.read('followers')).toBe(51);
+    });
+
     it('returns the written context', async () => {
       const user = await db.write('user', {
         name: 'Bob',

--- a/src/database/test/root.test.js
+++ b/src/database/test/root.test.js
@@ -1,43 +1,163 @@
 /* eslint-env mocha */
-import { Graph } from 'graph-crdt';
+import expect, { createSpy } from 'expect';
+import { Graph, Node } from 'graph-crdt';
+
+import { Storage } from './mocks';
 import Context from '../context';
 import database from '../root';
-import expect from 'expect';
 
-describe('A database', () => {
+describe('Database', () => {
   let db;
-
   const settings = database.configuration;
 
   beforeEach(() => {
     db = database();
   });
 
-  it('should be an object', () => {
+  it('is an object', () => {
     expect(db).toBeAn(Object);
   });
 
-  it('should generate a database configuration', () => {
+  it('generates a database configuration', () => {
     const config = db[settings];
     expect(config).toBeAn(Object);
   });
 
-  it('should create a new graph', () => {
+  it('creates a new graph', () => {
     expect(db).toBeA(Graph);
   });
 
   describe('read', () => {
-
-    it('should return null if nothing is found', async () => {
+    it('returns null if nothing is found', async () => {
       const settings = await db.read('settings');
       expect(settings).toBe(null);
     });
+  });
 
+  describe('commit', () => {
+    let graph, node, beforeWrite, afterWrite, storage;
+    const Identity = (value) => value;
+
+    beforeEach(() => {
+      beforeWrite = createSpy().andCall(Identity);
+      afterWrite = createSpy().andCall(Identity);
+      graph = new Graph();
+      node = new Node();
+
+      storage = new Storage();
+      storage.write = createSpy();
+
+      graph.merge({ [node]: node });
+
+      db = database({
+        hooks: {
+          before: {
+            write: beforeWrite,
+          },
+          after: {
+            write: afterWrite,
+          },
+        },
+
+        storage: [storage],
+      });
+    });
+
+    it('returns a promise', () => {
+      const result = db.commit(graph);
+
+      expect(result).toBeA(Promise);
+    });
+
+    it('triggers the before write pipeline', async () => {
+      await db.commit(graph);
+
+      expect(beforeWrite).toHaveBeenCalled();
+
+      const [pipe] = beforeWrite.calls[0].arguments;
+      expect(pipe.update).toBeA(Graph);
+      expect([...pipe.update]).toEqual([...graph]);
+    });
+
+    it('calls storage drivers', async () => {
+      await db.commit(graph);
+
+      expect(storage.write).toHaveBeenCalled();
+      const [write] = storage.write.calls[0].arguments;
+
+      expect(write.graph).toBeA(Graph);
+    });
+
+    it('passes the full state of each node to storage', async () => {
+      await db.write('state', { existing: true });
+      const update = new Graph();
+      const node = new Node({ uid: 'state' });
+      node.merge({ new: true });
+      update.merge({ [node]: node });
+      storage.write.reset();
+      await db.commit(update);
+
+      expect(storage.write).toHaveBeenCalled();
+      const [write] = storage.write.calls[0].arguments;
+      const state = write.graph.value('state');
+
+      expect([...state]).toEqual([
+        ...Node.from({
+          existing: true,
+          new: true,
+        }),
+      ]);
+    });
+
+    it('only contains nodes which updated', async () => {
+      const update = new Graph();
+
+      await db.write('unrelated', { ignore: 'please' });
+      storage.write.reset();
+      await db.commit(update);
+
+      const [write] = storage.write.calls[0].arguments;
+      expect(write.graph.value('unrelated')).toNotExist();
+    });
+
+    it('uses the storage options if given', async () => {
+      await db.commit(graph, { storage: [] });
+
+      expect(storage.write).toNotHaveBeenCalled();
+    });
+
+    it('caches the value after pipeline validation', async () => {
+      const node = Node.from({ updated: true });
+      graph.merge({ [node]: node });
+      await db.commit(graph);
+
+      const cached = db.value(String(node));
+      expect(cached).toExist();
+      expect([...cached]).toEqual([...node]);
+    });
+
+    it('triggers the after write pipeline', async () => {
+      await db.commit(graph);
+
+      expect(afterWrite).toHaveBeenCalled();
+      const [write] = afterWrite.calls[0].arguments;
+
+      expect(write.update).toBeA(Graph);
+      expect(write.graph).toBeA(Graph);
+    });
+
+    it('returns the deltas', async () => {
+      node.merge({ commit: null });
+      const result = await db.commit(graph);
+
+      expect(result).toBeAn(Object);
+      expect(result.history).toBeA(Graph);
+      expect(result.update).toBeA(Graph);
+    });
   });
 
   describe('write', () => {
-
-    it('should save to the graph', async () => {
+    it('saves to the graph', async () => {
       await db.write('user', { name: 'Jesse' });
 
       const node = db.value('user');
@@ -48,7 +168,7 @@ describe('A database', () => {
       expect(name).toBe('Jesse');
     });
 
-    it('should merge updates, not overwrite', async () => {
+    it('does not overwrite, instead merges', async () => {
       await db.write('user', { name: 'Bob' });
       await db.write('user', { handle: 'BobTheGreat' });
 
@@ -58,7 +178,7 @@ describe('A database', () => {
       expect(await user.read('handle')).toBe('BobTheGreat');
     });
 
-    it('should return the written context', async () => {
+    it('returns the written context', async () => {
       const user = await db.write('user', {
         name: 'Bob',
       });
@@ -69,15 +189,14 @@ describe('A database', () => {
       const name = await user.read('name');
       expect(name).toBe('Bob');
     });
-
   });
 
-  describe('extended API', () => {
+  describe('API extensions', () => {
     const extend = (api) => database({
       extend: { root: api },
     });
 
-    it('should be added', () => {
+    it('are added to the root', () => {
       const db = extend({
         method: () => true,
         prop: 'yep',
@@ -87,19 +206,17 @@ describe('A database', () => {
       expect(db.prop).toBe('yep');
     });
 
-    it('should be non-enumerable', () => {
+    it('are non-enumerable', () => {
       const db = extend({ prop: 'value' });
       const keys = Object.keys(db);
       expect(keys).toNotContain('prop');
     });
 
-    it('should be immutable', () => {
+    it('are immutable', () => {
       const db = extend({ stuff: 'original' });
       expect(() => {
         db.stuff = 'something else';
       }).toThrow(Error);
     });
-
   });
-
 });


### PR DESCRIPTION
Adds a new method, `db.commit(Graph)`, which applies many updates at once. Used internally for `Database#write` and `Context#write`.

Why? Without an explicit understanding of how Mytosis works, it's nearly impossible to apply many updates at once, even though `graph-crdt` is built for it. The new `commit()` method adds this ability.