### PR TITLE
Fix/config validation

### DIFF
--- a/packages/mytosis-websocket/src/__tests__/server.test.js
+++ b/packages/mytosis-websocket/src/__tests__/server.test.js
@@ -42,12 +42,6 @@ describe('Mytosis websocket server', () => {
     expect(fail).toThrow(/config/);
   });
 
-  it('throws if the port is invalid', () => {
-    const fail = () => new SocketServer({ port: 'wat' });
-
-    expect(fail).toThrow(/port/);
-  });
-
   it('registers clients when they connect', () => {
     const spy = jest.fn();
     server.on('add', spy);

--- a/packages/mytosis-websocket/src/server.js
+++ b/packages/mytosis-websocket/src/server.js
@@ -62,16 +62,11 @@ export default class SocketServer extends ConnectionGroup {
 
   /**
    * @param  {Object} config - Server options.
-   * @param  {Number} config.port - A port to listen on.
    */
   constructor (config) {
-    super();
-
     assert(config, `Expected config, got "${config}"`);
-    assert(
-      typeof config.port === 'number',
-      `Invalid config.port value "${config.port}" (expected number)`
-    );
+
+    super();
 
     const server = new Server(config);
     server.on('connection', (socket) => {


### PR DESCRIPTION
`config.port` was asserted to exist, though a `config.server` value can be used instead.