### PR TITLE
Do not validate port value

### DIFF
--- a/packages/mytosis-websocket/CHANGELOG.md
+++ b/packages/mytosis-websocket/CHANGELOG.md
@@ -2,5 +2,9 @@
 
 > This changelog adopts the [keep-a-changelog style](http://keepachangelog.com/en/0.3.0/) and adheres to [semver](http://semver.org/).
 
+## v0.1.1
+### Fixed
+- Removed validation from config enforcing a `port` field.
+
 ## v0.1.0
 Initial release.

--- a/packages/mytosis-websocket/package.json
+++ b/packages/mytosis-websocket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mytosis-websocket",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mytosis WebSocket plugin",
   "main": "client.js",
   "scripts": {

--- a/packages/mytosis-websocket/src/__tests__/server.test.js
+++ b/packages/mytosis-websocket/src/__tests__/server.test.js
@@ -42,12 +42,6 @@ describe('Mytosis websocket server', () => {
     expect(fail).toThrow(/config/);
   });
 
-  it('throws if the port is invalid', () => {
-    const fail = () => new SocketServer({ port: 'wat' });
-
-    expect(fail).toThrow(/port/);
-  });
-
   it('registers clients when they connect', () => {
     const spy = jest.fn();
     server.on('add', spy);

--- a/packages/mytosis-websocket/src/server.js
+++ b/packages/mytosis-websocket/src/server.js
@@ -62,16 +62,11 @@ export default class SocketServer extends ConnectionGroup {
 
   /**
    * @param  {Object} config - Server options.
-   * @param  {Number} config.port - A port to listen on.
    */
   constructor (config) {
-    super();
-
     assert(config, `Expected config, got "${config}"`);
-    assert(
-      typeof config.port === 'number',
-      `Invalid config.port value "${config.port}" (expected number)`
-    );
+
+    super();
 
     const server = new Server(config);
     server.on('connection', (socket) => {


### PR DESCRIPTION
The config can omit a port value and pass a server instead. I don't know
what I was thinking by forcing a port number.