### PR TITLE
Chore/remove multi storage option

### DIFF
--- a/packages/mytosis/src/database/root.js
+++ b/packages/mytosis/src/database/root.js
@@ -115,10 +115,14 @@ class Database extends Graph {
     };
 
     // Persist.
-    const writes = config.storage.map((store) => store.write(write));
+    const writes = [];
+
+    if (config.storage) {
+      writes.push(config.storage.write(write));
+    }
 
     if (this.router) {
-      await this.router.push(write);
+      this.router.push(write);
     }
 
     // Wait for writes to finish.
@@ -181,8 +185,12 @@ class Database extends Graph {
     // Not cached.
     if (node === null || config.force) {
 
+      const reads = [];
+
       // Ask the storage plugins for it.
-      const reads = [...config.storage].map(store => store.read(config));
+      if (config.storage) {
+        reads.push(config.storage.read(config));
+      }
 
       // Ask the network for it.
       if (this.router) {

--- a/packages/mytosis/src/database/test/hooks.test.js
+++ b/packages/mytosis/src/database/test/hooks.test.js
@@ -17,7 +17,7 @@ describe('Database hook', () => {
     beforeEach(() => {
       write = spyOn(storage, 'write').andCallThrough();
       db = database({
-        storage: [storage],
+        storage,
         hooks: {
           before: { write: hook },
         },
@@ -94,7 +94,7 @@ describe('Database hook', () => {
       read = spyOn(storage, 'read');
       hook = createSpy().andCall((read) => read);
       db = database({
-        storage: [storage],
+        storage,
         hooks: {
           before: {
             read: { node: hook },
@@ -191,7 +191,7 @@ describe('Database hook', () => {
     beforeEach(async () => {
       hook = createSpy().andCall((read) => read);
       db = database({
-        storage: [storage],
+        storage,
         hooks: {
           before: {
             read: { field: hook },

--- a/packages/mytosis/src/database/test/root.test.js
+++ b/packages/mytosis/src/database/test/root.test.js
@@ -163,7 +163,7 @@ describe('Database', () => {
 
       const config = branch[database.configuration];
 
-      expect(config.storage).toEqual([]);
+      expect(config.storage).toEqual(null);
     });
 
     it('does not contain network plugins', () => {

--- a/packages/mytosis/src/database/test/root.test.js
+++ b/packages/mytosis/src/database/test/root.test.js
@@ -226,7 +226,7 @@ describe('Database', () => {
           },
         },
 
-        storage: [storage],
+        storage,
 
         router: createSpy().andReturn(router),
       });
@@ -328,7 +328,7 @@ describe('Database', () => {
     });
 
     it('uses the storage options if given', async () => {
-      await db.commit(graph, { storage: [] });
+      await db.commit(graph, { storage: null });
 
       expect(storage.write).toNotHaveBeenCalled();
     });

--- a/packages/mytosis/src/database/test/storage.test.js
+++ b/packages/mytosis/src/database/test/storage.test.js
@@ -9,9 +9,7 @@ describe('Storage plugin', () => {
   beforeEach(() => {
     storage = new Storage();
 
-    db = database({
-      storage: [storage],
-    });
+    db = database({ storage });
   });
 
   describe('write', () => {
@@ -70,8 +68,9 @@ describe('Storage plugin', () => {
 
     it('is not called if storage is disabled', async () => {
       await db.write('users', {}, {
-        storage: [],
+        storage: null,
       });
+
       expect(write).toNotHaveBeenCalled();
     });
 
@@ -132,7 +131,7 @@ describe('Storage plugin', () => {
     });
 
     it('is not called if storage is disabled', async () => {
-      await db.read('key', { storage: [] });
+      await db.read('key', { storage: null });
       expect(read).toNotHaveBeenCalled();
     });
 
@@ -142,7 +141,7 @@ describe('Storage plugin', () => {
       storage.read = createSpy();
       storage.read.andReturn(node.toJSON());
 
-      const db = database({ storage: [storage] });
+      const db = database({ storage });
       const { uid } = node.meta();
 
       expect(await db.read(uid)).toBe(await db.read(uid));

--- a/packages/mytosis/src/merge-configs/index.js
+++ b/packages/mytosis/src/merge-configs/index.js
@@ -169,11 +169,7 @@ const merge = {
       throw new Error('Only one storage plugin allowed per database.');
     }
 
-    if (plugin && plugin.constructor === Object) {
-      return plugin;
-    }
-
-    return current;
+    return plugin || current;
   },
 
   /**

--- a/packages/mytosis/src/merge-configs/index.js
+++ b/packages/mytosis/src/merge-configs/index.js
@@ -28,10 +28,10 @@ export const base = {
   },
 
   /**
-   * A list of storage drivers.
-   * @type {Array}
+   * The given storage plugin.
+   * @type {Array|null}
    */
-  storage: [],
+  storage: null,
 
   /**
    * API extensions.
@@ -158,12 +158,23 @@ const merge = {
   },
 
   /**
-   * Merges two storage arrays together.
-   * @param  {Array} base - A list of storage interfaces.
-   * @param  {Array} ext=[] - A list of storage interfaces.
-   * @return {Array} - The merged list.
+   * Sets the storage context.
+   * @param  {Object} [current] - Current storage plugin.
+   * @param  {Object} [plugin] - A storage plugin.
+   * @throws {Error} - If two storage plugins are defined.
+   * @return {Object} - The storage plugin.
    */
-  storage: (base, ext = []) => base.concat(ext),
+  storage: (current, plugin) => {
+    if (current && plugin) {
+      throw new Error('Only one storage plugin allowed per database.');
+    }
+
+    if (plugin && plugin.constructor === Object) {
+      return plugin;
+    }
+
+    return current;
+  },
 
   /**
    * Merges two engine objects together.

--- a/packages/mytosis/src/merge-configs/test.js
+++ b/packages/mytosis/src/merge-configs/test.js
@@ -2,7 +2,7 @@
 import config, { base } from './index';
 import expect from 'expect';
 
-import ConnectionGroup from '../connection-group/';
+import ConnectionGroup from '../connection-group/index';
 
 describe('A config', () => {
   let result;
@@ -12,7 +12,7 @@ describe('A config', () => {
   });
 
   it('contains storage settings', () => {
-    expect(result.storage).toEqual([]);
+    expect(result.storage).toEqual(null);
   });
 
   it('contains query engines', () => {
@@ -51,27 +51,10 @@ describe('A config', () => {
     });
   });
 
-  it('merges read.field hooks', () => {
-    const field = (action) => action;
-    const node = (action) => action;
-
-    const { hooks } = config([{
-      hooks: {
-        before: { read: { node } },
-      },
-    }, {
-      hooks: {
-        before: { read: { field } },
-      },
-    }]);
-
-    expect(hooks.before.read.field).toEqual([field]);
-  });
-
   describe('merge', () => {
     it('does not add undefined items', () => {
       const { hooks, network, storage } = config([{}]);
-      expect(storage.length).toBe(0);
+      expect(storage).toBe(null);
       expect([...network].length).toBe(0);
       expect(hooks.before.read.node.length).toBe(0);
       expect(hooks.before.read.field.length).toBe(0);
@@ -108,24 +91,22 @@ describe('A config', () => {
     it('adds storage', () => {
       const storage = { name: 'Storage driver' };
 
-      const result = config([{
-        storage: [storage],
-      }]);
+      const result = config([{ storage }]);
 
-      expect(result.storage).toEqual([storage]);
+      expect(result.storage).toEqual(storage);
     });
 
-    it('merges unwrapped storage plugins', () => {
+    it('throws if several storage providers are given', () => {
       const store1 = { name: 'Storage driver #1' };
       const store2 = { name: 'Storage driver #2' };
 
-      const result = config([{
+      const fail = () => config([{
         storage: store1,
       }, {
         storage: store2,
       }]);
 
-      expect(result.storage).toEqual([store1, store2]);
+      expect(fail).toThrow(/storage/);
     });
 
     it('adds query engines', () => {
@@ -153,19 +134,6 @@ describe('A config', () => {
       const result = config([{ hooks }]);
 
       expect(result.hooks.before.write).toEqual([write]);
-    });
-
-    it('adds storage drivers in the order they\'re defined', () => {
-      const first = () => {};
-      const second = () => {};
-
-      const result = config([{
-        storage: [first],
-      }, {
-        storage: [second],
-      }]);
-
-      expect(result.storage).toEqual([first, second]);
     });
 
     it('adds hooks in the order they\'re defined', () => {

--- a/packages/mytosis/src/pipeline/index.js
+++ b/packages/mytosis/src/pipeline/index.js
@@ -19,7 +19,7 @@ export const defaults = (config, options = {}) => {
   return {
     ...options,
 
-    storage: storage || [],
+    storage: storage || null,
     network: network || new ConnectionGroup(),
   };
 };

--- a/packages/mytosis/src/pipeline/test.js
+++ b/packages/mytosis/src/pipeline/test.js
@@ -18,8 +18,8 @@ describe('The pipeline\'s default option setter', () => {
     group.add(conn);
 
     config = mergeConfigs([{
-      storage: [storage],
       network: group,
+      storage,
     }]);
   });
 
@@ -27,18 +27,18 @@ describe('The pipeline\'s default option setter', () => {
     const options = pipeline.defaults(config, {});
 
     expect(options).toContain({
-      storage: [storage],
       network: group,
+      storage,
     });
   });
 
   it('uses given storage options instead of the default', () => {
     const options = pipeline.defaults(config, {
-      storage: [{ custom: true }],
+      storage: { custom: true },
     });
 
     expect(options).toContain({
-      storage: [{ custom: true }],
+      storage: { custom: true },
       network: group,
     });
   });
@@ -51,8 +51,8 @@ describe('The pipeline\'s default option setter', () => {
     });
 
     expect(options).toContain({
-      storage: [storage],
       network: group,
+      storage,
     });
   });
 });
@@ -126,15 +126,15 @@ describe('The pipeline', () => {
         expect(result).toEqual({
           network: new ConnectionGroup(),
           setting: true,
-          storage: [],
+          storage: null,
         });
       });
 
       it('does not force defaults if otherwise specified', async () => {
         const options = {
-          setting: true,
-          storage: [{ storage: true }],
           network: [{ network: true }],
+          storage: { storage: true },
+          setting: true,
         };
 
         const config = hooks();
@@ -151,7 +151,7 @@ describe('The pipeline', () => {
 
         const result = await getPipeline(path)(config, options);
 
-        expect(result.storage).toEqual([]);
+        expect(result.storage).toEqual(null);
       });
 
       it('uses an empty network group if null is given', async () => {


### PR DESCRIPTION
The ability to have multiple storage layers didn't end up being useful, and only reduced visibility into the system. Having a single storage plugin simplifies much of the internals and removes a seemingly useless feature.