### PR TITLE
Feature/bulk reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ yarn add mytosis
 
 Now you can import it into your project.
 ```js
-// Using ES Modules
+// ES Modules
 import database from 'mytosis'
 
-// Using CommonJS (pffft, nobody uses that)
+// CommonJS
 const database = require('mytosis').default
 ```
 
@@ -81,7 +81,7 @@ const db = database()
 
 Most methods accept an `options` object as the last parameter, which supports the following:
 
-- `options.storage` - Overrides the storage defaults. Can be an array of plugins or `null`.
+- `options.storage` - Overrides the storage defaults. Can be a storage plugin or `null`.
 - `options.network` - Overrides the network defaults. Can be a `ConnectionGroup` or `null`.
 
 ### `db.read(key[, options])`
@@ -104,13 +104,29 @@ console.log('Stats:', stats)
 If the node can't be found, `null` is returned.
 
 #### Options
+Same options as [`db.nodes()`](#dbwritekey-patch-options).
 
-> **Note:** All standard options are supported.
+### `db.nodes([...keys][, options])`
+Reads many keys simultaneously, resolving with an array of nodes.
+
+> **Note:** This isn't just `Promise.all`. It's more performant than `db.read`, especially if you're querying the network.
+
+```js
+// Reads both `timeline` and `profile/<userid>`.
+const [timeline, profile] = await db.nodes(['timeline', `profile/${userId}`])
+
+console.log('Profile:', profile.snapshot())
+```
+
+If a node can't be found, it's value is `null`.
+
+#### Options
+All standard options are supported. In addition...
 
 - `options.force` - Ignore the in-memory cache and force a read from the plugins. Expects a boolean value.
 
 ### `db.write(key, patch[, options])`
-Updates properties on a node. If the node doesn't exist, it'll be created.
+Updates properties on a node. If the node doesn't exist, it's created.
 
 ```js
 db.write('preferences', {

--- a/README.md
+++ b/README.md
@@ -271,14 +271,14 @@ For example, here's a hook which adds a prefix to every read.
 const readHook = (readAction) => ({
   ...readAction,
 
-  key: `my-prefix/${readAction.key}`,
+  keys: readAction.keys.map((key) => `my-prefix/${key}`),
 })
 
 const db = database({
   hooks: {
     before: {
       read: {
-        node: readHook,
+        nodes: readHook,
       },
     },
   },
@@ -308,7 +308,7 @@ database({
     before: {
       write: hook,
       read: {
-        node: hook,
+        nodes: hook,
         field: hook,
       },
     },

--- a/packages/mytosis-leveldb/CHANGELOG.md
+++ b/packages/mytosis-leveldb/CHANGELOG.md
@@ -2,5 +2,9 @@
 
 > This changelog adopts the [keep-a-changelog style](http://keepachangelog.com/en/0.3.0/) and adheres to [semver](http://semver.org/).
 
+## Unreleased
+### Changed
+- Each read is now a bulk read from level, reflecting the Mytosis plugin api change.
+
 ## v0.1.0
 Initial release.

--- a/packages/mytosis-leveldb/src/__tests__/index.test.js
+++ b/packages/mytosis-leveldb/src/__tests__/index.test.js
@@ -36,7 +36,7 @@ describe('Mytosis LevelDB', () => {
     const data = { something: 'not really' };
     fakeLevel.get.mockImplementation((key, fn) => fn(null, data));
 
-    const value = await level.read({ key: 'key' });
+    const [value] = await level.read({ keys: ['key'] });
 
     expect(value).toEqual(data);
     expect(fakeLevel.get).toHaveBeenCalledWith('key', expect.any(Function));
@@ -47,9 +47,10 @@ describe('Mytosis LevelDB', () => {
     fakeLevel.get.mockImplementation((key, fn) => fn(err));
 
     const spy = jest.fn();
-    level.read({ key: 'dave' }).catch(spy);
+    level.read({ keys: ['dave'] }).catch(spy);
 
     // Wait for one promise tick.
+    await Promise.resolve();
     await Promise.resolve();
     expect(spy).toHaveBeenCalledWith(err);
   });
@@ -59,7 +60,7 @@ describe('Mytosis LevelDB', () => {
     error.type = 'NotFoundError';
 
     fakeLevel.get.mockImplementation((key, fn) => fn(error));
-    const value = await level.read({ key: 'potatoes' });
+    const [value] = await level.read({ keys: ['potatoes'] });
     expect(value).toBeUndefined();
   });
 

--- a/packages/mytosis-localstorage/CHANGELOG.md
+++ b/packages/mytosis-localstorage/CHANGELOG.md
@@ -2,5 +2,9 @@
 
 > This changelog adopts the [keep-a-changelog style](http://keepachangelog.com/en/0.3.0/).
 
+## Unreleased
+### Changed
+- Now `.read` accepts an array of keys, reflecting the new Mytosis plugin API.
+
 ## v0.1.0
 Initial release.

--- a/packages/mytosis-localstorage/src/__tests__/index.js
+++ b/packages/mytosis-localstorage/src/__tests__/index.js
@@ -80,16 +80,18 @@ describe('Mytosis LocalStorage', () => {
 
   describe('read()', () => {
     it('returns null if nothing exists', () => {
-      const result = store.read(node.meta().uid);
+      const result = store.read({
+        keys: [node.meta().uid],
+      });
 
-      expect(result).toBe(null);
+      expect(result).toEqual([null]);
     });
 
     it('returns the written item when it exists', () => {
       localStorage.getItem.mockReturnValue(JSON.stringify(node));
       const { uid } = node.meta();
 
-      const result = store.read({ key: uid });
+      const [result] = store.read({ keys: [uid] });
 
       expect(localStorage.getItem).toHaveBeenCalledWith(uid);
       expect(result).toEqual(node.toJSON());
@@ -97,7 +99,7 @@ describe('Mytosis LocalStorage', () => {
 
     it('uses the correct prefix', () => {
       const store = new LocalStoragePlugin({ prefix: 'cache-things/' });
-      store.read({ key: 'name' });
+      store.read({ keys: ['name'] });
 
       expect(localStorage.getItem).toHaveBeenCalledWith('cache-things/name');
     });

--- a/packages/mytosis-localstorage/src/index.js
+++ b/packages/mytosis-localstorage/src/index.js
@@ -71,15 +71,17 @@ module.exports = class LocalStoragePlugin {
    * @param  {String} write.key - Node index.
    * @return {Object|null} - Whatever was in localStorage.
    */
-  read ({ key }) {
-    const index = `${this.prefix}${key}`;
-    const result = this.backend.getItem(index);
+  read ({ keys }) {
+    return keys.map((key) => {
+      const index = `${this.prefix}${key}`;
+      const result = this.backend.getItem(index);
 
-    if (result) {
-      return JSON.parse(result);
-    }
+      if (result) {
+        return JSON.parse(result);
+      }
 
-    return null;
+      return null;
+    });
   }
 
   /**

--- a/packages/mytosis/CHANGELOG.md
+++ b/packages/mytosis/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 > This changelog adopts the [keep-a-changelog style](http://keepachangelog.com/en/0.3.0/).
 
-> Due to a versioning mistake, the official stable API will be defined in v2.0.0.
-**All `v1.x.x` versions should be considered unstable.**
+> Due to a rocky versioning history, the first stable release will be `v2.0.0`.
+**All `v1.x.x` versions are unstable.**
 
 ## Unreleased
 ### Fixed
 - The config `hooks.[before/after].read.field` was being improperly concatenated with node read hooks.
+
+### Changed
+- Storage plugins now get a list of keys to read, not just one. Reduces round-trip network requests and improves read performance for databases which support bulk reads.
 
 ## v1.11.0
 ### Added

--- a/packages/mytosis/src/database/root.js
+++ b/packages/mytosis/src/database/root.js
@@ -231,7 +231,7 @@ class Database extends Graph {
     const reads = [];
 
     // Terminate early if everything is already cached.
-    if (!absentFromCache.length) {
+    if (!absentFromCache.length && !config.force) {
       const result = await getFinalValue(config);
 
       return result.nodes;

--- a/packages/mytosis/src/database/root.js
+++ b/packages/mytosis/src/database/root.js
@@ -206,7 +206,7 @@ class Database extends Graph {
    * const [timeline, profile] = await db.nodes(['timeline', 'profile'])
    */
   async nodes (keys, options = {}) {
-    const config = await pipeline.before.read.node(this[settings], {
+    const config = await pipeline.before.read.nodes(this[settings], {
       ...options,
       offline: this[settings].network.filter(isOffline),
       keys,
@@ -216,7 +216,7 @@ class Database extends Graph {
     const getFinalValue = (action) => {
       const nodes = config.keys.map((key) => this.value(key));
 
-      return pipeline.after.read.node(this[settings], {
+      return pipeline.after.read.nodes(this[settings], {
         ...action,
         contexts: nodes,
       });

--- a/packages/mytosis/src/database/test/hooks.test.js
+++ b/packages/mytosis/src/database/test/hooks.test.js
@@ -84,7 +84,7 @@ describe('Database hook', () => {
     });
   });
 
-  describe('"before.read.node"', () => {
+  describe('"before.read.nodes"', () => {
     let read, hook;
 
     beforeEach(() => {
@@ -94,7 +94,7 @@ describe('Database hook', () => {
         storage,
         hooks: {
           before: {
-            read: { node: hook },
+            read: { nodes: hook },
           },
         },
       });
@@ -147,7 +147,7 @@ describe('Database hook', () => {
       db = database({
         hooks: {
           after: {
-            read: { node: hook },
+            read: { nodes: hook },
           },
         },
       });

--- a/packages/mytosis/src/database/test/hooks.test.js
+++ b/packages/mytosis/src/database/test/hooks.test.js
@@ -56,11 +56,9 @@ describe('Database hook', () => {
       expect(write).toNotHaveBeenCalled();
       expect(await db.read('user')).toBe(null);
     });
-
   });
 
   describe('"after.write"', () => {
-
     beforeEach(() => {
       db = database({
         hooks: {
@@ -84,7 +82,6 @@ describe('Database hook', () => {
         cool: true,
       });
     });
-
   });
 
   describe('"before.read.node"', () => {
@@ -113,14 +110,14 @@ describe('Database hook', () => {
       const options = { 'engage hyperdrive': true };
       await db.read('key name', options);
       const [read] = hook.calls[0].arguments;
-      expect(read.key).toBe('key name');
+      expect(read.keys).toEqual(['key name']);
       expect(read).toContain(options);
     });
 
     it('should allow overriding the key', async () => {
       hook.andCall((read) => ({
         ...read,
-        key: `prefix/${read.key}`,
+        key: `prefix/${read.keys[0]}`,
       }));
       await db.read('stuff');
       const [{ key }] = read.calls[0].arguments;
@@ -140,7 +137,6 @@ describe('Database hook', () => {
         original: true,
       });
     });
-
   });
 
   describe('"after.read.node"', () => {
@@ -170,19 +166,18 @@ describe('Database hook', () => {
       const data = await db.read('data', { cool: 'totally' });
       const [read] = hook.calls[0].arguments;
 
-      expect(read.context).toBe(data);
+      expect(read.contexts).toEqual([data]);
       expect(read).toContain({ cool: 'totally' });
     });
 
     it('should allow override of the return node', async () => {
       hook.andCall((read) => ({
         ...read,
-        context: 'haha, replaced!',
+        contexts: ['haha, replaced!'],
       }));
       const value = await db.read('data');
       expect(value).toBe('haha, replaced!');
     });
-
   });
 
   describe('"before.read.field"', () => {
@@ -238,7 +233,6 @@ describe('Database hook', () => {
       const [options] = read.calls[0].arguments;
       expect(options).toContain({ overridden: true });
     });
-
   });
 
   describe('"after.read.field"', () => {
@@ -298,7 +292,5 @@ describe('Database hook', () => {
       const value = await node.read('edge');
       expect(value).toBe('replaced value');
     });
-
   });
-
 });

--- a/packages/mytosis/src/database/test/integration.test.js
+++ b/packages/mytosis/src/database/test/integration.test.js
@@ -74,4 +74,24 @@ describe('The database', () => {
     expect(db.value('users/jenn').value('lastname')).toBe('Smith');
     expect(db.value('settings/jenn').value('notifications')).toBe('ENABLED');
   });
+
+  it('allows bulk reads', async () => {
+    await db.write('users/moss', {});
+    await db.write('users/trenneman', {});
+
+    const addNames = db.branch();
+    const [moss, roy] = await addNames.nodes(['users/moss', 'users/trenneman']);
+
+    await moss.write('name', 'Maurice');
+    await roy.write('name', 'Roy');
+    await db.commit(addNames);
+
+    expect((await db.read('users/moss')).snapshot()).toEqual({
+      name: 'Maurice',
+    });
+
+    expect((await db.read('users/trenneman')).snapshot()).toEqual({
+      name: 'Roy',
+    });
+  });
 });

--- a/packages/mytosis/src/database/test/root.test.js
+++ b/packages/mytosis/src/database/test/root.test.js
@@ -61,12 +61,16 @@ describe('Database', () => {
       const [read] = router.pull.calls[0].arguments;
 
       expect(read).toBeAn(Object);
-      expect(read.key).toBe('lobby');
+      expect(read.keys).toEqual(['lobby']);
     });
 
     it('resolves with the router response', async () => {
-      const data = Node.from({ response: 'router' }).toJSON();
-      router.pull.andReturn(data);
+      router.pull.andCall(() => {
+        const node = new Node({ uid: 'weather' });
+        node.merge({ response: 'router' });
+
+        return [node.toJSON()];
+      });
 
       const result = await db.read('weather');
       expect(result).toBeA(Context);
@@ -354,13 +358,13 @@ describe('Database', () => {
       expect(hook).toHaveBeenCalled();
       const [action] = hook.calls[0].arguments;
 
-      expect(action.nodes).toEqual(nodes);
+      expect(action.contexts).toEqual(nodes);
     });
 
     it('allows hooks to override the node values', async () => {
       const hook = createSpy().andCall((action) => ({
         ...action,
-        nodes: ['ha!'],
+        contexts: ['ha!'],
       }));
 
       const db = database({
@@ -377,7 +381,7 @@ describe('Database', () => {
     it('calls the post-read hooks for cached values', async () => {
       const hook = createSpy().andCall((action) => ({
         ...action,
-        nodes: ['replaced'],
+        contexts: ['replaced'],
       }));
 
       const db = database({

--- a/packages/mytosis/src/database/test/root.test.js
+++ b/packages/mytosis/src/database/test/root.test.js
@@ -391,6 +391,13 @@ describe('Database', () => {
 
       expect(nodes).toEqual(['replaced']);
     });
+
+    it('reads anyway if the read is forced', async () => {
+      await db.write('node', {});
+      await db.nodes(['node'], { force: true });
+
+      expect(storage.read).toHaveBeenCalled();
+    });
   });
 
   describe('branch()', () => {

--- a/packages/mytosis/src/database/test/root.test.js
+++ b/packages/mytosis/src/database/test/root.test.js
@@ -402,6 +402,17 @@ describe('Database', () => {
 
       expect(storage.read).toHaveBeenCalled();
     });
+
+    it('ignores nodes it did not ask for', async () => {
+      storage.read.andCall(async () => [
+        new Node({ uid: 'ignore-me' }),
+      ]);
+
+      const [node] = await db.nodes(['something-else']);
+
+      expect(node).toNotExist();
+      expect(db.value('ignore-me')).toBe(null);
+    });
   });
 
   describe('branch()', () => {

--- a/packages/mytosis/src/database/test/root.test.js
+++ b/packages/mytosis/src/database/test/root.test.js
@@ -330,7 +330,7 @@ describe('Database', () => {
       const db = database({
         storage,
         hooks: {
-          before: { read: { node: hook } },
+          before: { read: { nodes: hook } },
         },
       });
 
@@ -349,7 +349,7 @@ describe('Database', () => {
       const db = database({
         storage,
         hooks: {
-          after: { read: { node: hook } },
+          after: { read: { nodes: hook } },
         },
       });
 
@@ -369,7 +369,7 @@ describe('Database', () => {
 
       const db = database({
         hooks: {
-          after: { read: { node: hook } },
+          after: { read: { nodes: hook } },
         },
       });
 
@@ -386,7 +386,7 @@ describe('Database', () => {
 
       const db = database({
         hooks: {
-          after: { read: { node: hook } },
+          after: { read: { nodes: hook } },
         },
       });
 

--- a/packages/mytosis/src/database/test/storage.test.js
+++ b/packages/mytosis/src/database/test/storage.test.js
@@ -139,7 +139,7 @@ describe('Storage plugin', () => {
       const node = Node.from({ data: true });
       const storage = new Storage();
       storage.read = createSpy();
-      storage.read.andReturn(node.toJSON());
+      storage.read.andReturn([node.toJSON()]);
 
       const db = database({ storage });
       const { uid } = node.meta();

--- a/packages/mytosis/src/merge-configs/index.js
+++ b/packages/mytosis/src/merge-configs/index.js
@@ -2,7 +2,7 @@ import ConnectionGroup from '../connection-group/index';
 
 const hooks = {
   read: {
-    node: [],
+    nodes: [],
     field: [],
   },
   write: [],
@@ -54,14 +54,14 @@ const merge = {
   /**
    * Merges read hooks together.
    * @param  {Object} hooks - Read hooks.
-   * @param  {Function[]} hooks.node - Node-related read events.
+   * @param  {Function[]} hooks.nodes - Node-related read events.
    * @param  {Function[]} hooks.field - Field-related read events.
    * @param  {Object} target - Read-related hooks to add.
    * @return {Object} - The merged read hooks.
    */
-  read: ({ field, node }, target = {}) => ({
+  read: ({ field, nodes }, target = {}) => ({
     field: field.concat(target.field || []),
-    node: node.concat(target.node || []),
+    nodes: nodes.concat(target.nodes || []),
   }),
 
   /**

--- a/packages/mytosis/src/merge-configs/test.js
+++ b/packages/mytosis/src/merge-configs/test.js
@@ -37,7 +37,7 @@ describe('A config', () => {
   it('contains a hooks object', () => {
     const hook = {
       read: {
-        node: [],
+        nodes: [],
         field: [],
       },
       write: [],
@@ -56,7 +56,7 @@ describe('A config', () => {
       const { hooks, network, storage } = config([{}]);
       expect(storage).toBe(null);
       expect([...network].length).toBe(0);
-      expect(hooks.before.read.node.length).toBe(0);
+      expect(hooks.before.read.nodes.length).toBe(0);
       expect(hooks.before.read.field.length).toBe(0);
       expect(hooks.before.write.length).toBe(0);
       expect(hooks.before.request.length).toBe(0);
@@ -143,18 +143,18 @@ describe('A config', () => {
       const result = config([{
         hooks: {
           before: {
-            read: { node: first },
+            read: { nodes: first },
           },
         },
       }, {
         hooks: {
           before: {
-            read: { node: second },
+            read: { nodes: second },
           },
         },
       }]);
 
-      expect(result.hooks.before.read.node).toEqual([first, second]);
+      expect(result.hooks.before.read.nodes).toEqual([first, second]);
     });
 
     it('prefers later-defined extensions when conflicts happen', () => {

--- a/packages/mytosis/src/mocks.js
+++ b/packages/mytosis/src/mocks.js
@@ -13,10 +13,12 @@ export class Storage {
     }
   }
 
-  async read ({ key }) {
-    const value = this.cache[key];
+  async read ({ keys }) {
+    const saved = keys.map((key) => this.cache[key]).filter(Boolean);
 
-    return value && JSON.parse(value);
+    return saved.map((value) => (
+      JSON.parse(value)
+    ));
   }
 }
 

--- a/packages/mytosis/src/pipeline/index.js
+++ b/packages/mytosis/src/pipeline/index.js
@@ -54,7 +54,7 @@ const createPipeline = (path, transform = identity) => (
 
 export const before = {
   read: {
-    node: createPipeline(['before', 'read', 'node']),
+    nodes: createPipeline(['before', 'read', 'nodes']),
     field: createPipeline(['before', 'read', 'field']),
   },
 
@@ -65,7 +65,7 @@ export const before = {
 
 export const after = {
   read: {
-    node: createPipeline(['after', 'read', 'node']),
+    nodes: createPipeline(['after', 'read', 'nodes']),
     field: createPipeline(['after', 'read', 'field']),
   },
 

--- a/packages/mytosis/src/pipeline/test.js
+++ b/packages/mytosis/src/pipeline/test.js
@@ -57,16 +57,16 @@ describe('The pipeline\'s default option setter', () => {
   });
 });
 
-describe('The before.read.node pipeline', () => {
+describe('The before.read.nodes pipeline', () => {
   it('allows hooks to replace read options', async () => {
     const read = async () => ({ overridden: true });
     const config = hooks({
       before: {
-        read: { node: read },
+        read: { nodes: read },
       },
     });
 
-    const options = await pipeline.before.read.node(config, {
+    const options = await pipeline.before.read.nodes(config, {
       string: 'sup',
     });
 
@@ -76,13 +76,13 @@ describe('The before.read.node pipeline', () => {
 
 describe('The pipeline', () => {
   const methods = [
-    ['before', 'read', 'node'],
+    ['before', 'read', 'nodes'],
     ['before', 'read', 'field'],
     ['before', 'write'],
     ['before', 'request'],
     ['before', 'update'],
 
-    ['after', 'read', 'node'],
+    ['after', 'read', 'nodes'],
     ['after', 'read', 'field'],
     ['after', 'write'],
     ['after', 'request'],


### PR DESCRIPTION
Adds a new method: `db.nodes()`

It accepts a key list and resolves with the corresponding nodes.

```js
const [timeline, settings] = await db.nodes(['timeline', 'settings'])

// timeline & settings are contexts
settings.write('theme', 'dark')
```

This isn't the same as `Promise.all([db.read('timeline'), db.read('settings')])`. This is a breaking change in the persistence plugin contract. Instead of providing `action.key`, it passes an `action.keys` list, expecting the storage or router plugin to respond with a corresponding node array.

Why? Performance. Storage plugins can make more efficient queries if they know which keys to retrieve ahead of time, and it reduces the number of round trips over the network (especially if they're connected to their backend with a socket, like postgres, redis or mysql).

Why stop at one key level deep? Because you won't know the pointer on a nested node in advance, and pointers are a Mytosis thing (although they *could* be represented as foreign keys). The storage plugin would need to read the first level anyway, then find all the pointers and read the next level deep. That doesn't exclude the possibility of GraphQL style queries, they just have to be done at a higher level.

TL:DR; this is `db.commit()`, but for reads.