### PR TITLE
Turn nested nodes into edges

### DIFF
--- a/packages/mytosis/CHANGELOG.md
+++ b/packages/mytosis/CHANGELOG.md
@@ -5,6 +5,10 @@
 > Due to a rocky versioning history, the first stable release will be `v2.0.0`.
 **All `v1.x.x` versions are unstable.**
 
+## v1.13.0
+### Fixed
+- Root-level writes which contain nodes are resolved into pointers before writing.
+
 ## v1.12.0
 ### Fixed
 - The config `hooks.[before/after].read.field` was being improperly concatenated with node read hooks.

--- a/packages/mytosis/src/database/root.js
+++ b/packages/mytosis/src/database/root.js
@@ -109,8 +109,7 @@ class Database extends Graph {
     const graph = new Graph();
     const contexts = this.new();
 
-    for (const [id] of update) {
-      const node = update.value(id);
+    for (const [id, node] of update) {
 
       if (node instanceof Context) {
         contexts.merge({ [id]: node });
@@ -178,13 +177,20 @@ class Database extends Graph {
     const context = new Context(this, { uid });
     const current = this.value(uid);
 
-    // Ensure object updates increment state.
-    if (current && value) {
-      for (const field in value) {
-        if (value.hasOwnProperty(field)) {
-          context.merge({ [field]: current.value(field) });
-          context.meta(field).state = current.state(field);
-        }
+    for (const field in value) {
+      if (!value.hasOwnProperty(field)) {
+        continue;
+      }
+
+      // Turn nested nodes into edges.
+      if (value[field] instanceof Node) {
+        value[field] = { edge: String(value[field]) };
+      }
+
+      // Ensure object updates increment state.
+      if (current) {
+        context.merge({ [field]: current.value(field) });
+        context.meta(field).state = current.state(field);
       }
     }
 

--- a/packages/mytosis/src/database/test/root.test.js
+++ b/packages/mytosis/src/database/test/root.test.js
@@ -699,6 +699,15 @@ describe('Database', () => {
       const { uid } = node.meta();
       expect(db.value(uid)).toBeA(Context);
     });
+
+    it('turns node values into pointers', async () => {
+      const user = await db.write('user', {});
+      await db.write('users', { [user]: user });
+
+      expect(db.value('users').value(user)).toEqual({
+        edge: String(user),
+      });
+    });
   });
 
   describe('write()', () => {


### PR DESCRIPTION
If you do a root-level write which contains a node, previously it didn't
turn that node into an edge. Now it does.

Fixes #30.