### PR TITLE
Add `.fields()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,15 @@ const weather = await db.write('weather', {
 const temperature = await weather.read('temperature')
 ```
 
+### `node.fields([...keys][, options])`
+Read a list of fields in a single request. Pointers are resolved using `db.nodes` for efficient read batching.
+
+```js
+const [name, friends] = await user.fields(['name', 'friends'])
+```
+
+Standard options are accepted.
+
 ### `node.write(key, value[, options])`
 Writes a value to the node. The value can be any primitive.
 

--- a/packages/mytosis/CHANGELOG.md
+++ b/packages/mytosis/CHANGELOG.md
@@ -5,13 +5,17 @@
 > Due to a rocky versioning history, the first stable release will be `v2.0.0`.
 **All `v1.x.x` versions are unstable.**
 
+## Unreleased
+### Changed
+- `(before|after).read.field` hooks no longer get a single field. Instead they're passed an `action.fields` array.
+
 ## v1.13.0
 ### Fixed
 - Root-level writes which contain nodes are resolved into pointers before writing.
 
 ## v1.12.0
 ### Fixed
-- The config `hooks.[before/after].read.field` was being improperly concatenated with node read hooks.
+- The config `(before|after).read.field` was being improperly concatenated with node read hooks.
 
 ### Changed
 - Storage plugins now get a list of keys to read, not just one. Reduces round-trip network requests and improves read performance for databases which support bulk reads.

--- a/packages/mytosis/src/database/context.js
+++ b/packages/mytosis/src/database/context.js
@@ -63,7 +63,7 @@ export default class Context extends Node {
 
     // Resolve all the pointers at once, unless there aren't any.
     const results = pointers.length
-      ? await this.root.nodes(pointers) : [];
+      ? await this.root.nodes(pointers, config) : [];
 
     // Reassemble them into their key/value pairs.
     const nodes = {};

--- a/packages/mytosis/src/database/test/context.test.js
+++ b/packages/mytosis/src/database/test/context.test.js
@@ -83,8 +83,8 @@ describe('A context', () => {
       const settings = new Context(root, { uid: 'settings' });
       await node.write('settings', settings);
 
-      const read = spyOn(root, 'read');
-      read.andReturn(Promise.resolve(settings));
+      const read = spyOn(root, 'nodes');
+      read.andReturn(Promise.resolve([settings]));
 
       const result = await node.read('settings');
       expect(result).toBe(settings);

--- a/packages/mytosis/src/database/test/context.test.js
+++ b/packages/mytosis/src/database/test/context.test.js
@@ -63,6 +63,18 @@ describe('A context', () => {
 
       expect(result).toEqual([true, node, 'yep']);
     });
+
+    it('passes options to `nodes()`', async () => {
+      spyOn(root, 'nodes').andCallThrough();
+
+      await node.write('self', node);
+      await node.fields(['self'], { storage: null });
+
+      expect(root.nodes).toHaveBeenCalled();
+      const options = root.nodes.calls[0].arguments[1];
+      expect(options).toExist();
+      expect(options.storage).toBe(null);
+    });
   });
 
   describe('read()', () => {
@@ -88,8 +100,6 @@ describe('A context', () => {
 
       const result = await node.read('settings');
       expect(result).toBe(settings);
-
-      read.restore();
     });
   });
 

--- a/packages/mytosis/src/database/test/context.test.js
+++ b/packages/mytosis/src/database/test/context.test.js
@@ -28,8 +28,44 @@ describe('A context', () => {
     expect(uid).toBe('potatoes');
   });
 
-  describe('read', () => {
+  describe('fields()', () => {
+    it('returns a promise', () => {
+      const result = node.fields([]);
 
+      expect(result).toBeA(Promise);
+    });
+
+    it('resolves with an array', async () => {
+      const result = await node.fields([]);
+
+      expect(result).toBeAn(Array);
+    });
+
+    it('contains all the primitive fields', async () => {
+      node.merge({ one: true, two: 'also true' });
+      const result = await node.fields(['two', 'one']);
+
+      expect(result).toEqual(['also true', true]);
+    });
+
+    it('resolves pointers', async () => {
+      await node.write('self', node);
+      const fields = await node.fields(['self']);
+
+      expect(fields).toEqual([node]);
+    });
+
+    it('keeps nodes and primitives in the correct order', async () => {
+      node.merge({ primitive: true, another: 'yep' });
+      await node.write('self', node);
+
+      const result = await node.fields(['primitive', 'self', 'another']);
+
+      expect(result).toEqual([true, node, 'yep']);
+    });
+  });
+
+  describe('read()', () => {
     it('should return undefined if not found', async () => {
       const result = await node.read('nothing here');
       expect(result).toBe(undefined);
@@ -55,11 +91,9 @@ describe('A context', () => {
 
       read.restore();
     });
-
   });
 
-  describe('write', () => {
-
+  describe('write()', () => {
     it('should write as an edge when given a context', async () => {
       const settings = new Context(root, { uid: 'settings' });
       await node.write('settings', settings);
@@ -80,11 +114,9 @@ describe('A context', () => {
 
       expect(node.state('count')).toBe(3);
     });
-
   });
 
-  describe('"new" call', () => {
-
+  describe('new()', () => {
     it('should return a new context', () => {
       const copy = node.new();
       expect(copy).toBeA(Context);
@@ -113,7 +145,6 @@ describe('A context', () => {
       const copy = ctx.new();
       expect(copy.hello).toBe('coder');
     });
-
   });
 
   describe('API extension', () => {
@@ -146,7 +177,5 @@ describe('A context', () => {
         ctx.hey = 'change!';
       }).toThrow(Error);
     });
-
   });
-
 });

--- a/packages/mytosis/src/database/test/hooks.test.js
+++ b/packages/mytosis/src/database/test/hooks.test.js
@@ -181,7 +181,7 @@ describe('Database hook', () => {
   });
 
   describe('"before.read.fields"', () => {
-    let hook, node, read;
+    let hook, node;
 
     beforeEach(async () => {
       hook = createSpy().andCall((read) => read);
@@ -195,7 +195,7 @@ describe('Database hook', () => {
       });
 
       node = await db.write('context hook test', {});
-      read = spyOn(storage, 'read').andCallThrough();
+      spyOn(storage, 'read').andCallThrough();
     });
 
     it('is passed the fields, node, and options', async () => {

--- a/packages/mytosis/src/merge-configs/index.js
+++ b/packages/mytosis/src/merge-configs/index.js
@@ -3,7 +3,7 @@ import ConnectionGroup from '../connection-group/index';
 const hooks = {
   read: {
     nodes: [],
-    field: [],
+    fields: [],
   },
   write: [],
   update: [],
@@ -55,12 +55,12 @@ const merge = {
    * Merges read hooks together.
    * @param  {Object} hooks - Read hooks.
    * @param  {Function[]} hooks.nodes - Node-related read events.
-   * @param  {Function[]} hooks.field - Field-related read events.
+   * @param  {Function[]} hooks.fields - Field-related read events.
    * @param  {Object} target - Read-related hooks to add.
    * @return {Object} - The merged read hooks.
    */
-  read: ({ field, nodes }, target = {}) => ({
-    field: field.concat(target.field || []),
+  read: ({ fields, nodes }, target = {}) => ({
+    fields: fields.concat(target.fields || []),
     nodes: nodes.concat(target.nodes || []),
   }),
 

--- a/packages/mytosis/src/merge-configs/test.js
+++ b/packages/mytosis/src/merge-configs/test.js
@@ -38,7 +38,7 @@ describe('A config', () => {
     const hook = {
       read: {
         nodes: [],
-        field: [],
+        fields: [],
       },
       write: [],
       request: [],
@@ -56,8 +56,8 @@ describe('A config', () => {
       const { hooks, network, storage } = config([{}]);
       expect(storage).toBe(null);
       expect([...network].length).toBe(0);
+      expect(hooks.before.read.fields.length).toBe(0);
       expect(hooks.before.read.nodes.length).toBe(0);
-      expect(hooks.before.read.field.length).toBe(0);
       expect(hooks.before.write.length).toBe(0);
       expect(hooks.before.request.length).toBe(0);
       expect(hooks.before.update.length).toBe(0);

--- a/packages/mytosis/src/pipeline/index.js
+++ b/packages/mytosis/src/pipeline/index.js
@@ -55,7 +55,7 @@ const createPipeline = (path, transform = identity) => (
 export const before = {
   read: {
     nodes: createPipeline(['before', 'read', 'nodes']),
-    field: createPipeline(['before', 'read', 'field']),
+    fields: createPipeline(['before', 'read', 'fields']),
   },
 
   write: createPipeline(['before', 'write']),
@@ -66,7 +66,7 @@ export const before = {
 export const after = {
   read: {
     nodes: createPipeline(['after', 'read', 'nodes']),
-    field: createPipeline(['after', 'read', 'field']),
+    fields: createPipeline(['after', 'read', 'fields']),
   },
 
   write: createPipeline(['after', 'write']),

--- a/packages/mytosis/src/pipeline/test.js
+++ b/packages/mytosis/src/pipeline/test.js
@@ -77,13 +77,13 @@ describe('The before.read.nodes pipeline', () => {
 describe('The pipeline', () => {
   const methods = [
     ['before', 'read', 'nodes'],
-    ['before', 'read', 'field'],
+    ['before', 'read', 'fields'],
     ['before', 'write'],
     ['before', 'request'],
     ['before', 'update'],
 
     ['after', 'read', 'nodes'],
-    ['after', 'read', 'field'],
+    ['after', 'read', 'fields'],
     ['after', 'write'],
     ['after', 'request'],
     ['after', 'update'],


### PR DESCRIPTION
Reads fields in bulk. If any of the requested fields are pointers, they're grouped into a single `db.nodes()` request. Also provides symmetry with `db.nodes()`, and I'm all about symmetry.

Here's what it looks like:
```js
const [name, friends] = await user.fields(['name', 'friends'])
```