### PR TITLE
Add streaming interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ graph.merge({ change: node })
 await db.commit(graph)
 ```
 
+### Streaming
+You can read everything in the database as a stream of nodes. Streams use JavaScript [async iteration](https://github.com/tc39/proposal-async-iteration).
+
+```js
+for await (const node of db) {
+  console.log('Node ID:', String(node))
+}
+```
+
+Naturally those queries can be quite expensive, so by default they're only be run on the requesting machine. There's no network integration.
+
 ### Events
 Each mutation will emit an `"update"` event, passing a graph containing only the changes. There's also a `"history"` event when properties are overwritten. If you keep track of these deltas, you can roll time backwards and forwards.
 

--- a/packages/mytosis-leveldb/.babelrc
+++ b/packages/mytosis-leveldb/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["es2015", "stage-2"]
+  "presets": ["es2015", "stage-3"],
+  "plugins": [
+    "transform-runtime"
+  ]
 }

--- a/packages/mytosis-leveldb/CHANGELOG.md
+++ b/packages/mytosis-leveldb/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > This changelog adopts the [keep-a-changelog style](http://keepachangelog.com/en/0.3.0/) and adheres to [semver](http://semver.org/).
 
+## v0.3.0
+### Added
+- Ability to stream everything in the database.
+
 ## v0.2.0
 ### Changed
 - Each read is now a bulk read from level, reflecting the Mytosis plugin api change.

--- a/packages/mytosis-leveldb/package.json
+++ b/packages/mytosis-leveldb/package.json
@@ -23,15 +23,19 @@
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
-    "babel-preset-stage-2": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1",
+    "babel-runtime": "^6.23.0",
     "eslint": "^4.1.1",
     "eslint-config-llama": "^3.0.0",
     "eslint-plugin-babel": "^4.1.1",
     "graph-crdt": "^0.7.0",
     "jest": "^20.0.4"
   },
-  "dependencies": {},
+  "peerDependencies": {
+    "babel-runtime": "^6.23.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/PsychoLlama/mytosis.git"

--- a/packages/mytosis-leveldb/src/__tests__/index.test.js
+++ b/packages/mytosis-leveldb/src/__tests__/index.test.js
@@ -1,23 +1,39 @@
 import { Graph, Node } from 'graph-crdt';
+import { Readable } from 'stream';
 
 import LevelDB from '../index';
 
-describe('Mytosis LevelDB', () => {
-  const fakeLevel = {
-    batch: jest.fn(),
-    get: jest.fn(),
-  };
+const createFakeStream = (values) => {
+  const stream = new Readable({ objectMode: true });
+  stream.removeAllListeners = jest.fn(stream.removeAllListeners);
 
-  let level;
+  stream._read = jest.fn(() => { // eslint-disable-line
+    const [next = null] = values;
+    values = values.slice(1);
+
+    if (next instanceof Error) {
+      stream.emit('error', next);
+    } else {
+      stream.push(next);
+    }
+  });
+
+  return stream;
+};
+
+describe('Mytosis LevelDB', () => {
+  let level, backend;
 
   beforeEach(() => {
-    fakeLevel.get.mockReset();
-    fakeLevel.batch.mockReset();
-    fakeLevel.batch.mockImplementation((ops, fn) => fn());
+    const stream = createFakeStream([new Node()]);
 
-    level = new LevelDB({
-      backend: fakeLevel,
-    });
+    backend = {
+      createValueStream: jest.fn().mockReturnValue(stream),
+      batch: jest.fn((ops, fn) => fn()),
+      get: jest.fn(),
+    };
+
+    level = new LevelDB({ backend });
   });
 
   it('throws if the config is omitted', () => {
@@ -34,22 +50,22 @@ describe('Mytosis LevelDB', () => {
 
   it('reads values from levelDB', async () => {
     const data = { something: 'not really' };
-    fakeLevel.get.mockImplementation((key, fn) => fn(null, data));
+    backend.get.mockImplementation((key, fn) => fn(null, data));
 
     const [value] = await level.read({ keys: ['key'] });
 
     expect(value).toEqual(data);
-    expect(fakeLevel.get).toHaveBeenCalledWith('key', expect.any(Function));
+    expect(backend.get).toHaveBeenCalledWith('key', expect.any(Function));
   });
 
   it('rejects if an error is given', async () => {
     const err = new Error('oh no, something failed');
-    fakeLevel.get.mockImplementation((key, fn) => fn(err));
+    backend.get.mockImplementation((key, fn) => fn(err));
 
     const spy = jest.fn();
     level.read({ keys: ['dave'] }).catch(spy);
 
-    // Wait for one promise tick.
+    // Wait a few promise ticks.
     await Promise.resolve();
     await Promise.resolve();
     expect(spy).toHaveBeenCalledWith(err);
@@ -59,7 +75,7 @@ describe('Mytosis LevelDB', () => {
     const error = new Error('Something something Not Found');
     error.type = 'NotFoundError';
 
-    fakeLevel.get.mockImplementation((key, fn) => fn(error));
+    backend.get.mockImplementation((key, fn) => fn(error));
     const [value] = await level.read({ keys: ['potatoes'] });
     expect(value).toBeUndefined();
   });
@@ -73,12 +89,12 @@ describe('Mytosis LevelDB', () => {
 
     await level.write({ graph });
 
-    expect(fakeLevel.batch).toHaveBeenCalledWith(
+    expect(backend.batch).toHaveBeenCalledWith(
       expect.any(Array),
       expect.any(Function),
     );
 
-    const [update] = fakeLevel.batch.mock.calls[0];
+    const [update] = backend.batch.mock.calls[0];
     expect(update.length).toBe(2);
   });
 
@@ -90,11 +106,73 @@ describe('Mytosis LevelDB', () => {
     graph.merge({ [node]: node });
 
     const error = new Error('Something happened');
-    fakeLevel.batch.mockImplementation((ops, fn) => fn(error));
+    backend.batch.mockImplementation((ops, fn) => fn(error));
 
     const spy = jest.fn();
     await level.write({ graph }).catch(spy);
 
     expect(spy).toHaveBeenCalledWith(error);
+  });
+
+  // babel-eslint freaks out about async generators. Oodles of
+  // lines disabling eslint. Hide your eyes!
+  describe('async iterator', () => {
+    it('is defined', () => {
+      expect(Symbol.asyncIterator).toBeTruthy();
+      expect(level[Symbol.asyncIterator]).toEqual(expect.any(Function));
+    });
+
+    it('creates a value stream', async () => {
+      for await (const value of level) {} // eslint-disable-line
+      expect(backend.createValueStream).toHaveBeenCalled();
+    });
+
+    it('yields every value in the stream', async () => {
+      const stream = createFakeStream([new Node(), new Node()]);
+      backend.createValueStream.mockReturnValue(stream);
+      let run = 0;
+
+      for await (const value of level) { // eslint-disable-line
+        run += 1;
+      }
+
+      expect(run).toBe(2);
+    });
+
+    it('forwards errors', async () => {
+      const stream = createFakeStream([new Error('oh no!')]);
+      backend.createValueStream.mockReturnValue(stream);
+
+      try {
+        for await (const value of level) {} // eslint-disable-line
+        throw new Error('Should have thrown an error prior.');
+      } catch (error) {
+        expect(error.message).toMatch(/oh no/);
+        expect(error.message).not.toMatch(/uncaught/i);
+      }
+    });
+
+    it('destroys the stream after an error', async () => {
+      const stream = createFakeStream([new Error('failure!')]);
+      backend.createValueStream.mockReturnValue(stream);
+
+      try {
+        for await (const value of level) {} // eslint-disable-line
+      } catch (error) {
+        // Meh.
+      }
+
+      expect(stream.removeAllListeners).toHaveBeenCalledWith();
+    });
+
+    it('survives streams of empty databases', async () => {
+      const stream = createFakeStream([]);
+      backend.createValueStream.mockReturnValue(stream);
+
+      // Pray this doesn't time out.
+      for await (const value of level) { // eslint-disable-line
+        throw new Error('Should not have been called.');
+      }
+    });
   });
 });

--- a/packages/mytosis-leveldb/src/__tests__/index.test.js
+++ b/packages/mytosis-leveldb/src/__tests__/index.test.js
@@ -1,7 +1,11 @@
+// babel-eslint freaks out about async generators and semicolons.
+/* eslint-disable semi */
 import { Graph, Node } from 'graph-crdt';
 import { Readable } from 'stream';
 
 import LevelDB from '../index';
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 150;
 
 const createFakeStream = (values) => {
   const stream = new Readable({ objectMode: true });
@@ -14,7 +18,9 @@ const createFakeStream = (values) => {
     if (next instanceof Error) {
       stream.emit('error', next);
     } else {
-      stream.push(next);
+
+      // Real life isn't synchronous.
+      setTimeout(() => stream.push(next), 20);
     }
   });
 
@@ -114,8 +120,6 @@ describe('Mytosis LevelDB', () => {
     expect(spy).toHaveBeenCalledWith(error);
   });
 
-  // babel-eslint freaks out about async generators. Oodles of
-  // lines disabling eslint. Hide your eyes!
   describe('async iterator', () => {
     it('is defined', () => {
       expect(Symbol.asyncIterator).toBeTruthy();

--- a/packages/mytosis-leveldb/src/__tests__/index.test.js
+++ b/packages/mytosis-leveldb/src/__tests__/index.test.js
@@ -1,3 +1,4 @@
+/* global jasmine */
 // babel-eslint freaks out about async generators and semicolons.
 /* eslint-disable semi */
 import { Graph, Node } from 'graph-crdt';

--- a/packages/mytosis-leveldb/yarn.lock
+++ b/packages/mytosis-leveldb/yarn.lock
@@ -254,14 +254,6 @@ babel-generator@^6.18.0, babel-generator@^6.25.0:
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-babel-helper-bindify-decorators@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz#14c19e5f142d7b47f19a52431e52b1ccbc40a330"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
 babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
@@ -292,15 +284,6 @@ babel-helper-explode-assignable-expression@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
   dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-
-babel-helper-explode-class@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz#7dc2a3910dee007056e1e31d640ced3d54eaa9eb"
-  dependencies:
-    babel-helper-bindify-decorators "^6.24.1"
     babel-runtime "^6.22.0"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
@@ -412,18 +395,6 @@ babel-plugin-syntax-async-generators@^6.5.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
 
-babel-plugin-syntax-class-properties@^6.8.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
-
-babel-plugin-syntax-decorators@^6.13.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
-
-babel-plugin-syntax-dynamic-import@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
-
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -451,25 +422,6 @@ babel-plugin-transform-async-to-generator@^6.24.1:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
-
-babel-plugin-transform-class-properties@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
-  dependencies:
-    babel-helper-function-name "^6.24.1"
-    babel-plugin-syntax-class-properties "^6.8.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
-babel-plugin-transform-decorators@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz#788013d8f8c6b5222bdf7b344390dfd77569e24d"
-  dependencies:
-    babel-helper-explode-class "^6.24.1"
-    babel-plugin-syntax-decorators "^6.13.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-types "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -660,6 +612,12 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "0.9.11"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -710,15 +668,6 @@ babel-preset-jest@^20.0.3:
   dependencies:
     babel-plugin-jest-hoist "^20.0.3"
 
-babel-preset-stage-2@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz#d9e2960fb3d71187f0e64eec62bc07767219bdc1"
-  dependencies:
-    babel-plugin-syntax-dynamic-import "^6.18.0"
-    babel-plugin-transform-class-properties "^6.24.1"
-    babel-plugin-transform-decorators "^6.24.1"
-    babel-preset-stage-3 "^6.24.1"
-
 babel-preset-stage-3@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz#836ada0a9e7a7fa37cb138fb9326f87934a48395"
@@ -741,7 +690,7 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:

--- a/packages/mytosis-localstorage/.babelrc
+++ b/packages/mytosis-localstorage/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015", "stage-3"],
+  "plugins": [
+
+    // Defines Symbol.asyncIterator
+    "transform-runtime"
+  ]
 }

--- a/packages/mytosis-localstorage/package.json
+++ b/packages/mytosis-localstorage/package.json
@@ -29,12 +29,17 @@
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1",
     "eslint": "^4.1.1",
     "eslint-config-llama": "^3.0.0",
     "eslint-plugin-babel": "^4.1.1",
     "graph-crdt": "^0.7.0",
     "jest": "^20.0.4",
+    "regenerator-runtime": "^0.10.5"
+  },
+  "peerDependencies": {
     "regenerator-runtime": "^0.10.5"
   },
   "jest": {

--- a/packages/mytosis-localstorage/package.json
+++ b/packages/mytosis-localstorage/package.json
@@ -32,6 +32,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
+    "babel-runtime": "^6.23.0",
     "eslint": "^4.1.1",
     "eslint-config-llama": "^3.0.0",
     "eslint-plugin-babel": "^4.1.1",
@@ -40,7 +41,7 @@
     "regenerator-runtime": "^0.10.5"
   },
   "peerDependencies": {
-    "regenerator-runtime": "^0.10.5"
+    "babel-runtime": "^6.23.0"
   },
   "jest": {
     "setupFiles": [

--- a/packages/mytosis-localstorage/src/index.js
+++ b/packages/mytosis-localstorage/src/index.js
@@ -17,6 +17,16 @@ const validateBackend = (backend) => {
 };
 
 /**
+ * Determine if a key belongs to a prefix.
+ * @param  {String} prefix - Key prefix.
+ * @param  {String} key - A localStorage key.
+ * @return {Boolean} - Whether the key is correctly prefixed.
+ */
+const matchesPrefix = (prefix) => (key) => (
+  key.slice(0, prefix.length) === prefix
+);
+
+/**
  * Creates a localStorage plugin for Mytosis
  * @class LocalStoragePlugin
  */
@@ -92,5 +102,21 @@ module.exports = class LocalStoragePlugin {
   remove (id) {
     const index = `${this.prefix}${id}`;
     this.backend.removeItem(index);
+  }
+
+  /**
+   * Streams all the nodes from storage.
+   * @return {AsyncIterator<Node>} - Every node in localStorage.
+   */
+  async * [Symbol.asyncIterator] () {
+    const { backend, prefix } = this;
+    const isPrefixed = matchesPrefix(prefix);
+
+    for (const key in backend) {
+      if (backend.hasOwnProperty(key) && isPrefixed(key)) {
+        const string = backend.getItem(key);
+        yield JSON.parse(string);
+      }
+    }
   }
 };

--- a/packages/mytosis-localstorage/src/mock-localstorage.js
+++ b/packages/mytosis-localstorage/src/mock-localstorage.js
@@ -1,7 +1,11 @@
-global.localStorage = {
-  toString: jest.fn(() => '[object Storage]'),
-  removeItem: jest.fn(),
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  clear: jest.fn(),
-};
+function mockLocalStorage () { // eslint-disable-line require-jsdoc
+  global.localStorage = Object.defineProperties({}, {
+    mockReset: { value: mockLocalStorage },
+    removeItem: { value: jest.fn() },
+    getItem: { value: jest.fn() },
+    setItem: { value: jest.fn() },
+    clear: { value: jest.fn() },
+  });
+}
+
+mockLocalStorage();

--- a/packages/mytosis-localstorage/yarn.lock
+++ b/packages/mytosis-localstorage/yarn.lock
@@ -690,7 +690,7 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:

--- a/packages/mytosis-localstorage/yarn.lock
+++ b/packages/mytosis-localstorage/yarn.lock
@@ -254,6 +254,14 @@ babel-generator@^6.18.0, babel-generator@^6.24.1:
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
 babel-helper-call-delegate@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
@@ -271,6 +279,14 @@ babel-helper-define-map@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
     lodash "^4.2.0"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
@@ -310,6 +326,16 @@ babel-helper-regex@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
     lodash "^4.2.0"
+
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
@@ -360,6 +386,42 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-async-generators@^6.5.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-transform-async-generator-functions@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz#f058900145fd3e9907a6ddf28da59f215258a5db"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-generators "^6.5.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -529,11 +591,32 @@ babel-plugin-transform-es2015-unicode-regex@^6.24.1:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
+babel-plugin-transform-exponentiation-operator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-regenerator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz#b8da305ad43c3c99b4848e4fe4037b770d23c418"
   dependencies:
     regenerator-transform "0.9.11"
+
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
@@ -584,6 +667,16 @@ babel-preset-jest@^20.0.3:
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz#cbacaadecb5d689ca1e1de1360ebfc66862c178a"
   dependencies:
     babel-plugin-jest-hoist "^20.0.3"
+
+babel-preset-stage-3@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz#836ada0a9e7a7fa37cb138fb9326f87934a48395"
+  dependencies:
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-generator-functions "^6.24.1"
+    babel-plugin-transform-async-to-generator "^6.24.1"
+    babel-plugin-transform-exponentiation-operator "^6.24.1"
+    babel-plugin-transform-object-rest-spread "^6.22.0"
 
 babel-register@^6.24.1:
   version "6.24.1"


### PR DESCRIPTION
Databases are now asynchronously iterable. A for-await loop yields every
value in the storage plugin. Memory isn't consulted (use a for-of loop
for that).

Todo: upgrade `mytosis-localstorage` and `mytosis-leveldb` to support the new streaming interface, then add it to the docs.