### PR TITLE
Fix branched root contexts

### DIFF
--- a/packages/mytosis/CHANGELOG.md
+++ b/packages/mytosis/CHANGELOG.md
@@ -5,6 +5,10 @@
 > Due to a rocky versioning history, the first stable release will be `v2.0.0`.
 **All `v1.x.x` versions are unstable.**
 
+## Unreleased
+### Fixed
+- Writes in branches were affecting the source database (issue #40).
+
 ## v1.15.0
 ### Added
 - New API to stream every node from the database (uses `for-await` loops).

--- a/packages/mytosis/src/database/root.js
+++ b/packages/mytosis/src/database/root.js
@@ -94,6 +94,11 @@ class Database extends Graph {
 
     branch.merge(this);
 
+    // Set the correct graph root for each context.
+    for (const [, context] of branch) {
+      context.root = branch;
+    }
+
     return branch;
   }
 

--- a/packages/mytosis/src/database/test/root.test.js
+++ b/packages/mytosis/src/database/test/root.test.js
@@ -500,6 +500,31 @@ describe('Database', () => {
       expect(node).toBeA(Node);
       expect([...node]).toEqual([['name', 'Bob']]);
     });
+
+    it('sets the correct graph root', async () => {
+      await db.write('node', {});
+      const branch = db.branch();
+      const node = await branch.read('node');
+
+      expect(node.root).toBe(branch, 'Context has incorrect root reference');
+    });
+
+    it('does not mutate other branch context roots', async () => {
+      const original = await db.write('node', {});
+      const branch = db.branch();
+      const node = await branch.read('node');
+
+      expect(original.root).toNotBe(node.root);
+    });
+
+    it('does not affect other nodes with writes', async () => {
+      const original = await db.write('node', {});
+      const branch = db.branch();
+      const node = await branch.read('node');
+      await node.write('value', true);
+
+      expect(original.snapshot()).toEqual({});
+    });
   });
 
   describe('commit()', () => {


### PR DESCRIPTION
Nodes copied into a branch used the wrong root context, causing writes
to affect storage and network plugins. Fixes #40