### PR TITLE
Add composite migrations

### DIFF
--- a/packages/types/src/Composite.js
+++ b/packages/types/src/Composite.js
@@ -3,6 +3,32 @@ import assert from 'minimalistic-assert';
 
 import Derivation from './Derivation';
 import Primitive from './Primitive';
+import type {
+  DefaultTypeChange,
+  TypeChange,
+  Remove,
+  Move,
+  Add,
+} from './migrations';
+
+const initialProps = {
+  lastComposite: {
+    writable: true,
+    value: null,
+  },
+  nextComposite: {
+    writable: true,
+    value: null,
+  },
+  lastVersion: {
+    writable: true,
+    value: null,
+  },
+  nextVersion: {
+    writable: true,
+    value: null,
+  },
+};
 
 /**
  * Creates object-style types.
@@ -10,7 +36,15 @@ import Primitive from './Primitive';
 export default class Composite {
   definition: FieldSet;
   defaultType: ?Field;
+
   name: string;
+  CRDT: CRDT;
+
+  lastVersion: ?Composite;
+  nextVersion: ?Composite;
+
+  lastComposite: ?Composite;
+  nextComposite: ?Composite;
 
   /**
    * @param  {String} name - A name for the type.
@@ -24,11 +58,15 @@ export default class Composite {
 
     this.name = name;
     Object.defineProperties(this, {
+      ...initialProps,
       definition: {
         value: def.initialFieldSet || {},
       },
       defaultType: {
         value: def.defaultType || null,
+      },
+      CRDT: {
+        value: def.CRDT,
       },
     });
   }
@@ -59,14 +97,50 @@ export default class Composite {
       }
     }
   }
+
+  /**
+   * Creates a new migration set.
+   * @param  {Migration[]} operations - A list of type changes.
+   * @return {Composite} - A new composite with the changes applied.
+   */
+  migrate(operations: Migration[]): Composite {
+    assert(operations.length, 'Migration list is empty.');
+
+    // Apply all migrations into a new composite.
+    const migrated = operations.reduce((composite, migration) => {
+      const { defaultType, definition } = migration.migrateType(composite);
+
+      const result = new Composite(composite.name, {
+        initialFieldSet: definition,
+        CRDT: composite.CRDT,
+        defaultType,
+      });
+
+      return Object.assign(result, { lastComposite: composite });
+    }, this);
+
+    // Go back and add a successor reference to each composite.
+    operations.reverse().reduce(composite => {
+      if (!composite || !composite.lastComposite) {
+        return composite;
+      }
+
+      composite.lastComposite.nextComposite = composite;
+
+      return composite.lastComposite;
+    }, migrated);
+
+    return Object.assign(migrated, { lastVersion: this });
+  }
 }
 
+type Migration = Add | Remove | Move | TypeChange | DefaultTypeChange;
 type Field = Primitive | Derivation;
 type FieldSet = { [field: string]: Field };
 type CRDT = { import(data: Object): Object };
 type ValidationTarget = { [string]: string | number | boolean };
 type Definition = {
   initialFieldSet?: FieldSet,
-  defaultType?: Field,
+  defaultType?: ?Field,
   CRDT: CRDT,
 };

--- a/packages/types/src/__tests__/Composite.test.js
+++ b/packages/types/src/__tests__/Composite.test.js
@@ -205,13 +205,19 @@ describe('Composite', () => {
 
       expect(v2.lastComposite).toEqual(expect.any(Composite));
       expect(v1.nextComposite).toEqual(expect.any(Composite));
+      expect(v2.lastComposite.nextComposite).toBe(v2);
       expect(v2.lastComposite.lastComposite.lastComposite.lastComposite).toBe(
         v1,
       );
+
       expect(v2.lastComposite.definition).toEqual({ gamertag: string });
       expect(v2.lastComposite.lastComposite.definition).toEqual({
         gamertag: string,
         name: string,
+      });
+
+      expect(v1.nextComposite.nextComposite.nextComposite.definition).toEqual({
+        gamertag: string,
       });
     });
 
@@ -228,6 +234,30 @@ describe('Composite', () => {
 
       expect(v2.lastVersion).toBe(v1);
       expect(v2.nextVersion).toBe(null);
+    });
+
+    it('keeps a reference to each migration', () => {
+      const user = new Composite('User', { CRDT });
+      expect(user.migration).toBe(null);
+
+      user.migrate([
+        new migrations.Add('firstName', string),
+        new migrations.Remove('firstName'),
+      ]);
+
+      expect(user.migration).toEqual(expect.any(migrations.Add));
+      expect(user.nextComposite.migration).toEqual(
+        expect.any(migrations.Remove),
+      );
+    });
+
+    it('throws if you migrate the same composite twice', () => {
+      const v1 = new Composite('User', { CRDT });
+      const migrate = () =>
+        v1.migrate([new migrations.Add('fullName', string)]);
+
+      expect(migrate).not.toThrow();
+      expect(migrate).toThrow(/(migrate|migration)/i);
     });
   });
 });

--- a/packages/types/src/__tests__/migrations.test.js
+++ b/packages/types/src/__tests__/migrations.test.js
@@ -5,7 +5,6 @@ import Primitive from '../Primitive';
 import {
   DefaultTypeChange,
   TypeChange,
-  Migration,
   Remove,
   Move,
   Add,
@@ -46,13 +45,6 @@ describe('Migration', () => {
     });
 
   describe('Add', () => {
-    it('creates a migration', () => {
-      const migration = new Add('name', string);
-
-      expect(migration).toEqual(expect.any(Migration));
-      expect(migration.name).toBe('ADD');
-    });
-
     it('updates the field set', () => {
       const type = createType();
       const migration = new Add('joined', string);
@@ -86,13 +78,6 @@ describe('Migration', () => {
   });
 
   describe('Remove', () => {
-    it('creates a migration', () => {
-      const migration = new Remove('gamertag');
-
-      expect(migration).toEqual(expect.any(Migration));
-      expect(migration.name).toBe('REMOVE');
-    });
-
     it('drops the field from the type', () => {
       const migration = new Remove('gamertag');
       const type = createType();
@@ -125,13 +110,6 @@ describe('Migration', () => {
   });
 
   describe('TypeChange', () => {
-    it('creates a migration', () => {
-      const migration = new TypeChange('gamertag', number);
-
-      expect(migration).toEqual(expect.any(Migration));
-      expect(migration.name).toBe('CHANGE_TYPE');
-    });
-
     it('throws if the field does not exist', () => {
       const migration = new TypeChange('bacon', string);
       const type = createType();
@@ -189,13 +167,6 @@ describe('Migration', () => {
   });
 
   describe('Move', () => {
-    it('creates a new migration', () => {
-      const migration = new Move('firstName', 'lastName');
-
-      expect(migration).toEqual(expect.any(Migration));
-      expect(migration.name).toBe('MOVE');
-    });
-
     it('throws if the source field is undefined', () => {
       const migration = new Move('noSuchField', 'lastName');
       const type = createType();
@@ -262,13 +233,6 @@ describe('Migration', () => {
   });
 
   describe('DefaultTypeChange', () => {
-    it('creates a migration', () => {
-      const migration = new DefaultTypeChange(string);
-
-      expect(migration).toEqual(expect.any(Migration));
-      expect(migration.name).toBe('CHANGE_DEFAULT_TYPE');
-    });
-
     it('creates the correct type', () => {
       const migration = new DefaultTypeChange(number);
       const type = createType();

--- a/packages/types/src/migrations.js
+++ b/packages/types/src/migrations.js
@@ -12,23 +12,8 @@ type CompositeTypeMap = {
   defaultType: ?AnyType,
 };
 
-/** Represents a simple type/data migration. */
-export class Migration {
-  operation: Function;
-  name: string;
-
-  /**
-   * @param  {String} name - Identifier for the migration type.
-   * @param  {Function} operation - Constructing function.
-   */
-  constructor(name: string) {
-    Object.defineProperty(this, 'operation', { value: this.constructor });
-    this.name = name;
-  }
-}
-
 /** Represents an ADD migration. */
-export class Add extends Migration {
+export class Add {
   field: string;
   type: AnyType;
 
@@ -37,8 +22,6 @@ export class Add extends Migration {
    * @param  {Type} type - The type to use.
    */
   constructor(field: string, type: AnyType) {
-    super('ADD');
-
     Object.defineProperties(this, {
       field: { value: field },
       type: { value: type },
@@ -79,15 +62,13 @@ export class Add extends Migration {
 }
 
 /** Represents a DROP operation. */
-export class Remove extends Migration {
+export class Remove {
   field: string;
 
   /**
    * @param  {string} field - The field to drop.
    */
   constructor(field: string) {
-    super('REMOVE');
-
     Object.defineProperties(this, {
       field: { value: field },
     });
@@ -128,7 +109,7 @@ export class Remove extends Migration {
 }
 
 /** Changes the type of a field. */
-export class TypeChange extends Migration {
+export class TypeChange {
   field: string;
   type: AnyType;
 
@@ -137,8 +118,6 @@ export class TypeChange extends Migration {
    * @param  {Type} type - Any type.
    */
   constructor(field: string, type: AnyType) {
-    super('CHANGE_TYPE');
-
     Object.defineProperties(this, {
       field: { value: field },
       type: { value: type },
@@ -189,7 +168,7 @@ export class TypeChange extends Migration {
 }
 
 /** Moves data from one field to another. */
-export class Move extends Migration {
+export class Move {
   from: string;
   to: string;
 
@@ -198,8 +177,6 @@ export class Move extends Migration {
    * @param  {String} to - The field to migrate into (destructive).
    */
   constructor(from: string, to: string) {
-    super('MOVE');
-
     Object.defineProperties(this, {
       from: { value: from },
       to: { value: to },
@@ -254,15 +231,13 @@ export class Move extends Migration {
 }
 
 /** Changes the implied type of a composite */
-export class DefaultTypeChange extends Migration {
+export class DefaultTypeChange {
   type: ?AnyType;
 
   /**
    * @param  {Type} type - Any type.
    */
   constructor(type: ?AnyType) {
-    super('CHANGE_DEFAULT_TYPE');
-
     Object.defineProperty(this, 'type', { value: type });
   }
 

--- a/packages/types/src/migrations.js
+++ b/packages/types/src/migrations.js
@@ -4,9 +4,8 @@ import assert from 'minimalistic-assert';
 import type Composite from './Composite';
 import Derivation from './Derivation';
 import Primitive from './Primitive';
-import type Union from './Union';
 
-type AnyType = Primitive | Derivation | Union | Composite;
+type AnyType = Primitive | Derivation;
 
 type CompositeTypeMap = {
   definition: { [string]: AnyType },
@@ -23,7 +22,7 @@ export class Migration {
    * @param  {Function} operation - Constructing function.
    */
   constructor(name: string) {
-    this.operation = this.constructor;
+    Object.defineProperty(this, 'operation', { value: this.constructor });
     this.name = name;
   }
 }
@@ -40,8 +39,10 @@ export class Add extends Migration {
   constructor(field: string, type: AnyType) {
     super('ADD');
 
-    this.field = field;
-    this.type = type;
+    Object.defineProperties(this, {
+      field: { value: field },
+      type: { value: type },
+    });
   }
 
   /**
@@ -87,7 +88,9 @@ export class Remove extends Migration {
   constructor(field: string) {
     super('REMOVE');
 
-    this.field = field;
+    Object.defineProperties(this, {
+      field: { value: field },
+    });
   }
 
   /**
@@ -136,8 +139,10 @@ export class TypeChange extends Migration {
   constructor(field: string, type: AnyType) {
     super('CHANGE_TYPE');
 
-    this.field = field;
-    this.type = type;
+    Object.defineProperties(this, {
+      field: { value: field },
+      type: { value: type },
+    });
   }
 
   /**
@@ -195,8 +200,10 @@ export class Move extends Migration {
   constructor(from: string, to: string) {
     super('MOVE');
 
-    this.from = from;
-    this.to = to;
+    Object.defineProperties(this, {
+      from: { value: from },
+      to: { value: to },
+    });
   }
 
   /**
@@ -209,7 +216,8 @@ export class Move extends Migration {
     const definition = { ...type.definition };
     const sourceExists = definition.hasOwnProperty(this.from);
     const targetExists = definition.hasOwnProperty(this.to);
-    const fail = field => `Field "${field}" isn't defined in type ${type.name}`;
+    const fail = field =>
+      `Field "${field}" isn't defined in type ${type.name}.`;
     assert(sourceExists, fail(this.from));
     assert(targetExists, fail(this.to));
 
@@ -255,7 +263,7 @@ export class DefaultTypeChange extends Migration {
   constructor(type: ?AnyType) {
     super('CHANGE_DEFAULT_TYPE');
 
-    this.type = type;
+    Object.defineProperty(this, 'type', { value: type });
   }
 
   /**


### PR DESCRIPTION
Now you can migrate composites. Passing a list of migrations will return
a new composite with each migration applied. Still need to add a few
things though:

- Throw if a migration is called on the same composite twice
- Keep a reference to the migration in each composite
- Make migrations less dumb (remove the migration name and base class)

Here's how it looks:

```js
const Task1 = new Composite('Task', {
  initialFieldSet: {title: string},
})

const Task2 = Task1.migrate([
  new migration.Add('requester', new Pointer(string, User)),
  new migration.Add('description', string),
])

console.log(Task2.definition) // {title: string, description: string, requester: pointer}
```

I don't expect this to be the final API, but the final API will use this underneath.