### PR TITLE
Feature/streams

### DIFF
--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -33,5 +33,8 @@
     "babel-runtime": "^6.26.0",
     "flow-copy-source": "^1.2.1",
     "jest": "^21.2.1"
+  },
+  "dependencies": {
+    "minimalistic-assert": "^1.0.0"
   }
 }

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@mytosis/streams",
+  "version": "0.1.0",
+  "description": "Cache-free lazy observables for modelling async event streams",
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "jest",
+    "transpile": "babel src/ -d dist/ --ignore __tests__",
+    "build": "yarn transpile && flow-copy-source src dist --ignore __tests__",
+    "prepare": "yarn build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PsychoLlama/mytosis.git"
+  },
+  "keywords": [
+    "stream",
+    "async",
+    "cacheless",
+    "emitter",
+    "pipe",
+    "pipeline"
+  ],
+  "author": "Jesse Gibson <overlord@psychollama.io> (http://psychollama.io)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/PsychoLlama/mytosis/issues"
+  },
+  "homepage": "https://github.com/PsychoLlama/mytosis#readme",
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-runtime": "^6.26.0",
+    "flow-copy-source": "^1.2.1",
+    "jest": "^21.2.1"
+  }
+}

--- a/packages/streams/src/__tests__/stream.test.js
+++ b/packages/streams/src/__tests__/stream.test.js
@@ -1,0 +1,94 @@
+// @flow
+import Stream from '../stream';
+
+describe('Stream', () => {
+  it('is a function', () => {
+    expect(Stream).toEqual(expect.any(Function));
+  });
+
+  it('does not immediately invoke the publisher', () => {
+    const publisher = jest.fn();
+    const stream = new Stream(publisher);
+
+    expect(stream).toEqual(expect.any(Stream));
+    expect(publisher).not.toHaveBeenCalled();
+  });
+
+  it('invokes the publisher with one observer', () => {
+    const publisher = jest.fn();
+    const stream = new Stream(publisher);
+    stream.forEach(jest.fn());
+
+    expect(publisher).toHaveBeenCalled();
+  });
+
+  it('does not open the publisher if already open', () => {
+    const publisher = jest.fn();
+    const stream = new Stream(publisher);
+    stream.forEach(jest.fn());
+    stream.forEach(jest.fn());
+
+    expect(publisher).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies subscribers of each new message', () => {
+    const msg = { yolo: true };
+    const stream = new Stream(push => push(msg));
+    const subscriber = jest.fn();
+    stream.forEach(subscriber);
+
+    expect(subscriber).toHaveBeenCalledWith(msg);
+  });
+
+  it('allows subscribers to unsubscribe', () => {
+    const publisher = jest.fn();
+    const stream = new Stream(publisher);
+    const subscriber = jest.fn();
+    const dispose = stream.forEach(subscriber);
+    dispose();
+    const [push] = publisher.mock.calls[0];
+    push({ new: 'message' });
+
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  it('allows the same function to subscribe twice', () => {
+    const publisher = jest.fn();
+    const stream = new Stream(publisher);
+    const subscriber = jest.fn();
+    stream.forEach(subscriber);
+    stream.forEach(subscriber);
+    publisher.mock.calls[0][0]({ some: 'message' });
+
+    expect(subscriber).toHaveBeenCalledTimes(2);
+  });
+
+  it('only unsubscribes the first subscriber when duplicates exist', () => {
+    const publisher = jest.fn();
+    const stream = new Stream(publisher);
+    const subscriber = jest.fn();
+    const dispose = stream.forEach(subscriber);
+    stream.forEach(subscriber);
+    dispose();
+    publisher.mock.calls[0][0]({ yolo: 'battlecry' });
+
+    expect(subscriber).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws if you unsubscribe twice', () => {
+    const stream = new Stream(jest.fn());
+    const dispose = stream.forEach(jest.fn());
+    dispose();
+
+    expect(dispose).toThrow(/listener/i);
+  });
+
+  it('closes the stream when the listener unsubscribes', () => {
+    const close = jest.fn();
+    const stream = new Stream(() => close);
+    const dispose = stream.forEach(jest.fn());
+    dispose();
+
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/packages/streams/src/__tests__/stream.test.js
+++ b/packages/streams/src/__tests__/stream.test.js
@@ -204,5 +204,32 @@ describe('Stream', () => {
       // eslint-disable-next-line no-underscore-dangle
       expect(stream._subscribers).toHaveLength(0);
     });
+
+    it('terminates the stream on rejection', async () => {
+      const close = jest.fn();
+      const error = new Error('Testing stream rejection cleanup');
+      const stream = new Stream((push, resolve, reject) => {
+        reject(error);
+        return close;
+      });
+
+      await stream.catch(jest.fn());
+
+      expect(close).toHaveBeenCalled();
+    });
+
+    it('does not call `close` twice if resolved twice', async () => {
+      const close = jest.fn();
+      await new Stream((push, resolve) => {
+        Promise.resolve().then(() => {
+          resolve({});
+          resolve({});
+        });
+
+        return close;
+      });
+
+      expect(close).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/streams/src/stream.js
+++ b/packages/streams/src/stream.js
@@ -327,14 +327,12 @@ export default class Stream<Message, Result = void> {
    * @return {Stream} - A new event stream.
    */
   map<Output>(transform: Message => Output): Stream<Output, Result> {
-    const stream: Stream<Output, Result> = new Stream(push => {
-      const dispose = this.forEach(message => {
+    const stream: Stream<Output, Result> = new Stream(push =>
+      this.forEach(message => {
         const mapped = transform(message);
         push(mapped);
-      });
-
-      return dispose;
-    });
+      }),
+    );
 
     // Stream maps cannot affect the promise. Sharing here is safe.
     stream._deferredResult = this._deferredResult;

--- a/packages/streams/src/stream.js
+++ b/packages/streams/src/stream.js
@@ -362,4 +362,24 @@ export default class Stream<Message, Result = void> {
       }),
     );
   }
+
+  /**
+   * Filters values out of a stream before passing them onward.
+   * @param  {Function} predicate - Determines whether to keep the value.
+   * @return {Stream} - A new stream missing inadequate values.
+   */
+  filter(predicate: Message => boolean): Stream<Message, Result> {
+    const stream = new Stream(push =>
+      this.observe(event => {
+        if (!event.done && predicate(event.value)) {
+          push(event.value);
+        }
+      }),
+    );
+
+    // Stream maps cannot affect the promise. Sharing here is safe.
+    stream._deferredResult = this._deferredResult;
+
+    return stream;
+  }
 }

--- a/packages/streams/src/stream.js
+++ b/packages/streams/src/stream.js
@@ -1,0 +1,124 @@
+// @flow
+import assert from 'minimalistic-assert';
+
+type PublishMessage<Message> = Message => void;
+type CloseStreamHandler = ?() => void;
+type Publisher<Message> = (PublishMessage<Message>) => CloseStreamHandler;
+type Subscriber<Message> = Message => any;
+
+// Locates the splice-friendly index of a subscriber in an array.
+// .findIndex() is unsupported in IE.
+const findSubscriber = (arr: Function[], subscriber: Function) => {
+  let index = arr.length;
+
+  arr.some((sub, idx) => {
+    const foundSubscriber = sub === subscriber;
+
+    if (foundSubscriber) {
+      index = idx;
+    }
+
+    return foundSubscriber;
+  });
+
+  return index;
+};
+
+// eslint-disable-next-line valid-jsdoc
+/** Creates a lazy pipe-driven event stream (cacheless). */
+export default class Stream<Message: Object> {
+  _closeStreamHandler: CloseStreamHandler;
+  _subscribers: Subscriber<Message>[];
+  _publisher: Publisher<Message>;
+  _open: boolean;
+
+  /**
+   * @param  {Function} publisher - Responsible for publishing events.
+   */
+  constructor(publisher: Publisher<Message>) {
+    Object.defineProperties(this, {
+      _publisher: {
+        value: publisher,
+      },
+      _open: {
+        writable: true,
+        value: false,
+      },
+      _subscribers: {
+        value: [],
+      },
+      _closeStreamHandler: {
+        writable: true,
+        value: null,
+      },
+    });
+  }
+
+  /**
+   * Opens the stream if it isn't open already.
+   * @private
+   * @return {void}
+   */
+  _openStream() {
+    if (this._open) {
+      return;
+    }
+
+    this._open = true;
+    const close = this._publisher(this._publishMessage);
+
+    if (close) {
+      this._closeStreamHandler = close;
+    }
+  }
+
+  /**
+   * Terminates the stream, but not permanently.
+   * @private
+   * @return {void}
+   */
+  _closeStream() {
+    if (this._closeStreamHandler) {
+      this._closeStreamHandler();
+    }
+  }
+
+  /**
+   * Publishes a message to all active subscribers.
+   * @private
+   * @param  {Object} message - Any message.
+   * @return {void}
+   */
+  _publishMessage: PublishMessage<Message> = (message: Message) => {
+    this._subscribers.forEach(subscriber => subscriber(message));
+  };
+
+  /**
+   * Observes stream events.
+   * @throws {Error} - If you unsubscribe twice (indicates a memory leak).
+   * @param  {Function} subscriber - Stream observer called for every message.
+   * @return {Function} - Unsubscribes when called.
+   */
+  forEach(subscriber: Subscriber<Message>): () => void {
+    this._subscribers.push(subscriber);
+    this._openStream();
+
+    let unsubscribed;
+    const dispose = () => {
+      assert(
+        !unsubscribed,
+        `Listener had already been removed. dispose() should only be called once.`,
+      );
+
+      unsubscribed = true;
+      const index = findSubscriber(this._subscribers, subscriber);
+      this._subscribers.splice(index, 1);
+
+      if (!this._subscribers.length) {
+        this._closeStream();
+      }
+    };
+
+    return dispose;
+  }
+}

--- a/packages/streams/src/stream.js
+++ b/packages/streams/src/stream.js
@@ -100,9 +100,12 @@ export default class Stream<Message: Object, Result> {
     }
 
     this._open = true;
-    const { reject } = this._deferredResult;
 
-    const close = this._publisher(this._publishMessage, this._resolve, reject);
+    const close = this._publisher(
+      this._publishMessage,
+      this._resolve,
+      this._reject,
+    );
 
     if (close) {
       if (this.closed) {
@@ -116,6 +119,11 @@ export default class Stream<Message: Object, Result> {
   _resolve: ResolveStream<Result> = (result: Result) => {
     this._terminateStream();
     this._deferredResult.resolve(result);
+  };
+
+  _reject = (error: Error) => {
+    this._terminateStream();
+    this._deferredResult.reject(error);
   };
 
   /**


### PR DESCRIPTION
Adds a new `@mytosis/streams` package with compositional cacheless observables. Similar API to the legacy `mytosis/src/stream` implementation, but with added coolness:
- Streams can terminate with a value, and implements the `.then` interface (allowing you to `await` a stream)
- Type safety. Using the power of Flow, you can only emit values compatible with the collection type (for example, `Stream<ReduxAction>` works in the same way as `Promise<ReduxAction>`).

**Example**
```js
const stream: Stream<number, number> = new Stream((push, resolve) => {
  let i = 0, sum = 0

  const interval = setInterval(() => {
    sum += ++i
    push(i)
    if (i >= 10) resolve(sum)
  }, 100)

  return () => clearInterval(interval)
})

stream.forEach(value => console.log('New value:', value))
console.log('Sum:', await stream)
// Stream finished, `clearInterval` called automatically.
```

Why build this? Because many events in Mytosis could strongly benefit from an async stream model, like storage read streams, incoming network messages, data stream map functions, etc.

Worth noting this is different from `Observable` instances in RxJS. There is no cache. If you miss an event, nothing saves it for you. It's gone forever. This is highly desirable, as a stream might represent every incoming message on a server.