### PR TITLE
Implement bare read stream

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -34,8 +34,9 @@
     "jest": "^21.2.1"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "@mytosis/crdts": "^0.1.0",
-    "@mytosis/types": "^0.1.0"
+    "@mytosis/streams": "^0.1.0",
+    "@mytosis/types": "^0.1.0",
+    "babel-runtime": "^6.26.0"
   }
 }

--- a/packages/db/src/__tests__/database-context.test.js
+++ b/packages/db/src/__tests__/database-context.test.js
@@ -1,4 +1,6 @@
 // @flow
+import Stream from '@mytosis/streams';
+
 import { create as createConfig } from '../config-utils';
 import DBContext from '../database-context';
 
@@ -66,6 +68,37 @@ describe('Database context', () => {
       const read = context.createReadDescriptor(keys, { network });
 
       expect(read.network.router).toEqual(network.router);
+    });
+
+    it('throws if the key set is empty', () => {
+      const context = setup();
+      const fail = () => context.createReadDescriptor([]);
+
+      expect(fail).toThrow(/(empty|key)/i);
+    });
+  });
+
+  describe('createReadStream()', () => {
+    const setup = (config = createConfig(), keys = ['user1', 'user2']) => {
+      const context = new DBContext(config);
+      const read = context.createReadDescriptor(keys);
+
+      return { context, read };
+    };
+
+    it('returns a stream', () => {
+      const { context, read } = setup();
+      const stream = context.createReadStream(read);
+
+      expect(stream).toEqual(expect.any(Stream));
+    });
+
+    it('returns an array of null if there are no plugins', async () => {
+      const { context, read } = setup();
+      const stream = context.createReadStream(read).toArray();
+
+      const expected = Array(read.keys.length).fill(null);
+      await expect(stream).resolves.toEqual(expected);
     });
   });
 });

--- a/packages/db/src/database-context.js
+++ b/packages/db/src/database-context.js
@@ -1,4 +1,7 @@
 // @flow
+import assert from 'minimalistic-assert';
+import Stream from '@mytosis/streams';
+
 import type { Options, Config } from './config-utils';
 
 type ReadDescriptor = Config & {
@@ -23,10 +26,23 @@ export default class DatabaseContext {
    * @return {Object} - Instructions on how to read a set of keys.
    */
   createReadDescriptor(keys: string[], options?: Options): ReadDescriptor {
+    assert(keys.length, 'A list of keys is required, but this one is empty.');
+
     return {
       ...this.config,
       ...options,
       keys,
     };
+  }
+
+  /**
+   * Opens a read stream from the given plugin set.
+   * @param  {ReadDescriptor} descriptor - Parameters describing the read.
+   * @return {Stream} - Outputs every node as it finds it.
+   */
+  createReadStream(descriptor: ReadDescriptor): Stream<null> {
+    const result = descriptor.keys.map(() => null);
+
+    return Stream.from(result);
   }
 }


### PR DESCRIPTION
Basically just returns a read stream. I might bounce to a vertex
implementation after this, so I have material to put in the stream and
an idea of how serialization happens.

EDIT: after diving down the vertex rabbit hole, the schema ended up being a blocker. I need that to build a vertex implementation to wrap a CRDT to serialize to a storage implementation to be read into a stream.